### PR TITLE
feat: redesign admin page builder experience

### DIFF
--- a/admin/api/page_builder.php
+++ b/admin/api/page_builder.php
@@ -76,6 +76,21 @@ try {
             respond(previewInstance($db, $renderer, $payload));
             break;
 
+        case 'POST:create-page':
+            $payload = getRequestBody();
+            respond(createPage($db, $payload));
+            break;
+
+        case 'POST:update-page':
+            $payload = getRequestBody();
+            respond(updatePage($db, $payload));
+            break;
+
+        case 'POST:delete-page':
+            $payload = getRequestBody();
+            respond(deletePage($db, $payload));
+            break;
+
         default:
             throw new InvalidArgumentException('Azione non supportata');
     }
@@ -87,7 +102,7 @@ try {
 
 function getPages(PDO $db): array
 {
-    $stmt = $db->query('SELECT id, title, slug FROM pages ORDER BY title');
+    $stmt = $db->query('SELECT id, title, slug, status FROM pages ORDER BY title');
     return $stmt->fetchAll() ?: [];
 }
 
@@ -113,7 +128,7 @@ function getModules(PDO $db, ModuleRenderer $renderer): array
 
 function getPageData(PDO $db, ModuleRenderer $renderer, int $pageId): array
 {
-    $pageStmt = $db->prepare('SELECT id, title, slug FROM pages WHERE id = ?');
+    $pageStmt = $db->prepare('SELECT id, title, slug, status FROM pages WHERE id = ?');
     $pageStmt->execute([$pageId]);
     $page = $pageStmt->fetch();
 
@@ -121,7 +136,7 @@ function getPageData(PDO $db, ModuleRenderer $renderer, int $pageId): array
         throw new InvalidArgumentException('Pagina non trovata');
     }
 
-    $modulesStmt = $db->prepare('SELECT id, module_name, instance_name, config, order_index, is_active
+    $modulesStmt = $db->prepare('SELECT id, module_name, instance_name, config, order_index, parent_instance_id, is_active
         FROM module_instances
         WHERE page_id = ?
         ORDER BY order_index');
@@ -142,13 +157,16 @@ function getPageData(PDO $db, ModuleRenderer $renderer, int $pageId): array
             'module' => $row['module_name'],
             'instance_name' => $row['instance_name'],
             'order_index' => (int)$row['order_index'],
+            'parent_instance_id' => $row['parent_instance_id'] !== null ? (int)$row['parent_instance_id'] : null,
             'html' => $html,
+            'config' => $mergedConfig,
         ];
     }
 
     return [
         'page' => $page,
         'instances' => $instances,
+        'tree' => $renderer->buildModuleInstanceTree($instances),
     ];
 }
 
@@ -165,6 +183,18 @@ function saveInstance(PDO $db, ModuleRenderer $renderer, array $payload): array
 
     $config = extractConfigPayload($payload['config'] ?? []);
     $currentId = null;
+    $parentInstanceId = null;
+
+    if (array_key_exists('parent_instance_id', $payload)) {
+        $rawParent = $payload['parent_instance_id'];
+        if ($rawParent !== null && $rawParent !== '' && $rawParent !== 'null') {
+            if (is_string($rawParent) && strpos($rawParent, 'temp') === 0) {
+                $parentInstanceId = null;
+            } else {
+                $parentInstanceId = (int)$rawParent;
+            }
+        }
+    }
 
     if (isset($payload['instance_id'])) {
         $instanceIdValue = $payload['instance_id'];
@@ -190,12 +220,13 @@ function saveInstance(PDO $db, ModuleRenderer $renderer, array $payload): array
         }
 
         if ($currentId) {
-            $updateStmt = $db->prepare('UPDATE module_instances SET module_name = ?, instance_name = ?, config = ?, order_index = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?');
+            $updateStmt = $db->prepare('UPDATE module_instances SET module_name = ?, instance_name = ?, config = ?, order_index = ?, parent_instance_id = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?');
             $updateStmt->execute([
                 $moduleName,
                 $instanceName,
                 json_encode($config, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
                 $orderIndex ?? 0,
+                $parentInstanceId,
                 $currentId,
             ]);
             $instanceId = $currentId;
@@ -206,13 +237,14 @@ function saveInstance(PDO $db, ModuleRenderer $renderer, array $payload): array
                 $orderIndex = (int)($orderStmt->fetchColumn() ?? 0);
             }
 
-            $insertStmt = $db->prepare('INSERT INTO module_instances (page_id, module_name, instance_name, config, order_index) VALUES (?, ?, ?, ?, ?)');
+            $insertStmt = $db->prepare('INSERT INTO module_instances (page_id, module_name, instance_name, config, order_index, parent_instance_id) VALUES (?, ?, ?, ?, ?, ?)');
             $insertStmt->execute([
                 $pageId,
                 $moduleName,
                 $instanceName,
                 json_encode($config, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
                 $orderIndex,
+                $parentInstanceId,
             ]);
             $instanceId = (int)$db->lastInsertId();
         }
@@ -233,6 +265,7 @@ function saveInstance(PDO $db, ModuleRenderer $renderer, array $payload): array
             'module' => $moduleName,
             'instance_name' => $instanceName,
             'order_index' => $orderIndex ?? 0,
+            'parent_instance_id' => $parentInstanceId,
             'html' => $html,
             'config' => $mergedConfig,
         ],
@@ -248,12 +281,14 @@ function updateOrder(PDO $db, array $payload): array
 
     $db->beginTransaction();
     try {
-        $stmt = $db->prepare('UPDATE module_instances SET order_index = ? WHERE id = ?');
+        $stmt = $db->prepare('UPDATE module_instances SET order_index = ?, parent_instance_id = ? WHERE id = ?');
         foreach ($updates as $update) {
             if (!isset($update['id'])) {
                 continue;
             }
-            $stmt->execute([(int)$update['order_index'], (int)$update['id']]);
+            $parent = $update['parent_instance_id'] ?? null;
+            $parent = $parent !== null ? (int)$parent : null;
+            $stmt->execute([(int)$update['order_index'], $parent, (int)$update['id']]);
         }
         $db->commit();
     } catch (Throwable $throwable) {
@@ -271,10 +306,23 @@ function deleteInstance(PDO $db, array $payload): array
         throw new InvalidArgumentException('ID istanza non valido');
     }
 
-    $stmt = $db->prepare('DELETE FROM module_instances WHERE id = ?');
-    $stmt->execute([$instanceId]);
+    deleteInstanceRecursive($db, $instanceId);
 
     return ['success' => true];
+}
+
+function deleteInstanceRecursive(PDO $db, int $instanceId): void
+{
+    $childStmt = $db->prepare('SELECT id FROM module_instances WHERE parent_instance_id = ?');
+    $childStmt->execute([$instanceId]);
+    $children = $childStmt->fetchAll(PDO::FETCH_COLUMN, 0) ?: [];
+
+    foreach ($children as $childId) {
+        deleteInstanceRecursive($db, (int)$childId);
+    }
+
+    $stmt = $db->prepare('DELETE FROM module_instances WHERE id = ?');
+    $stmt->execute([$instanceId]);
 }
 
 function getModuleConfig(PDO $db, ModuleRenderer $renderer, array $payload): array
@@ -322,6 +370,81 @@ function previewModule(ModuleRenderer $renderer, array $payload): array
         'html' => $html,
         'config' => $mergedConfig,
     ];
+}
+
+function createPage(PDO $db, array $payload): array
+{
+    $title = trim((string)($payload['title'] ?? ''));
+    $slug = trim((string)($payload['slug'] ?? ''));
+
+    if ($title === '') {
+        throw new InvalidArgumentException('Il titolo della pagina è obbligatorio');
+    }
+
+    if ($slug === '') {
+        $slug = strtolower(preg_replace('/[^a-z0-9]+/i', '-', $title));
+        $slug = trim($slug, '-');
+    }
+
+    $stmt = $db->prepare('INSERT INTO pages (title, slug, status) VALUES (?, ?, ?)');
+    $stmt->execute([$title, $slug, 'draft']);
+
+    $pageId = (int)$db->lastInsertId();
+
+    return [
+        'success' => true,
+        'page' => [
+            'id' => $pageId,
+            'title' => $title,
+            'slug' => $slug,
+            'status' => 'draft',
+        ],
+    ];
+}
+
+function updatePage(PDO $db, array $payload): array
+{
+    $pageId = isset($payload['page_id']) ? (int)$payload['page_id'] : 0;
+    $title = trim((string)($payload['title'] ?? ''));
+    $slug = trim((string)($payload['slug'] ?? ''));
+
+    if ($pageId <= 0) {
+        throw new InvalidArgumentException('Pagina non valida');
+    }
+
+    if ($title === '') {
+        throw new InvalidArgumentException('Il titolo è obbligatorio');
+    }
+
+    if ($slug === '') {
+        $slug = strtolower(preg_replace('/[^a-z0-9]+/i', '-', $title));
+        $slug = trim($slug, '-');
+    }
+
+    $stmt = $db->prepare('UPDATE pages SET title = ?, slug = ? WHERE id = ?');
+    $stmt->execute([$title, $slug, $pageId]);
+
+    return [
+        'success' => true,
+        'page' => [
+            'id' => $pageId,
+            'title' => $title,
+            'slug' => $slug,
+        ],
+    ];
+}
+
+function deletePage(PDO $db, array $payload): array
+{
+    $pageId = isset($payload['page_id']) ? (int)$payload['page_id'] : 0;
+    if ($pageId <= 0) {
+        throw new InvalidArgumentException('Pagina non valida');
+    }
+
+    $stmt = $db->prepare('DELETE FROM pages WHERE id = ?');
+    $stmt->execute([$pageId]);
+
+    return ['success' => true];
 }
 
 function previewInstance(PDO $db, ModuleRenderer $renderer, array $payload): array

--- a/admin/assets/js/page-builder.js
+++ b/admin/assets/js/page-builder.js
@@ -1,0 +1,1103 @@
+(() => {
+    const state = {
+        pages: [],
+        currentPageId: null,
+        currentPage: null,
+        tree: [],
+        modules: [],
+        availableModules: [],
+        selectedNodeId: null,
+        inlineMode: false,
+        tempCounter: 0,
+        moduleCounters: {},
+        changes: {
+            added: new Set(),
+            updated: new Set(),
+            deleted: new Set(),
+        },
+        nodeIndex: new Map(),
+        inspector: null,
+    };
+
+    const dom = {
+        pageSelector: document.getElementById('pb-page-selector'),
+        createPageBtn: document.getElementById('pb-create-page'),
+        renamePageBtn: document.getElementById('pb-rename-page'),
+        deletePageBtn: document.getElementById('pb-delete-page'),
+        moduleCount: document.getElementById('pb-module-count'),
+        moduleSearch: document.getElementById('pb-module-search'),
+        modulesList: document.getElementById('pb-modules'),
+        stage: document.getElementById('pb-stage'),
+        stageName: document.getElementById('pb-current-page-name'),
+        stageSlug: document.getElementById('pb-current-page-slug'),
+        inlineToggle: document.getElementById('pb-inline-toggle'),
+        previewBtn: document.getElementById('pb-preview-page'),
+        inspectorBody: document.getElementById('pb-inspector-body'),
+        inspectorLabel: document.getElementById('pb-selected-label'),
+        saveConfigBtn: document.getElementById('pb-save-config'),
+        cancelInlineBtn: document.getElementById('pb-cancel-inline'),
+        changeBadges: document.getElementById('pb-change-badges'),
+        toast: document.getElementById('pb-toast'),
+    };
+
+    const sortables = [];
+    let inspectorState = null;
+
+    function init() {
+        if (!window.PB_INITIAL_STATE) {
+            return;
+        }
+
+        state.pages = PB_INITIAL_STATE.pages || [];
+        state.currentPageId = PB_INITIAL_STATE.currentPageId || (state.pages[0]?.id ?? null);
+        state.currentPage = PB_INITIAL_STATE.currentPage || null;
+        state.modules = PB_INITIAL_STATE.moduleInstances || [];
+        state.availableModules = PB_INITIAL_STATE.availableModules || [];
+        state.tree = buildTree(state.modules);
+        rebuildIndex();
+        initModuleCounters();
+
+        bindEvents();
+        renderPageSelector();
+        renderModuleLibrary();
+        renderStage();
+        updateStageHeader();
+        updateChangeBadges();
+    }
+
+    function bindEvents() {
+        dom.pageSelector.addEventListener('change', () => {
+            const nextId = parseInt(dom.pageSelector.value, 10);
+            if (!Number.isNaN(nextId)) {
+                loadPage(nextId);
+            }
+        });
+
+        dom.createPageBtn.addEventListener('click', handleCreatePage);
+        dom.renamePageBtn.addEventListener('click', handleRenamePage);
+        dom.deletePageBtn.addEventListener('click', handleDeletePage);
+        dom.moduleSearch.addEventListener('input', renderModuleLibrary);
+        dom.inlineToggle.addEventListener('click', toggleInlineMode);
+        dom.previewBtn.addEventListener('click', previewCurrentPage);
+        dom.saveConfigBtn.addEventListener('click', persistCurrentInspector);
+        dom.cancelInlineBtn.addEventListener('click', cancelInlineDraft);
+    }
+
+    function buildTree(instances) {
+        if (!Array.isArray(instances)) {
+            return [];
+        }
+
+        const byParent = new Map();
+        instances.forEach((instance) => {
+            const parentKey = instance.parent_instance_id ?? null;
+            if (!byParent.has(parentKey)) {
+                byParent.set(parentKey, []);
+            }
+            const node = {
+                id: instance.id,
+                module: instance.module,
+                instance_name: instance.instance_name,
+                order_index: instance.order_index ?? 0,
+                parent_instance_id: instance.parent_instance_id ?? null,
+                html: instance.html ?? '',
+                config: instance.config || {},
+                children: [],
+                isNew: false,
+                inlineDraft: null,
+                _configDirty: false,
+            };
+            byParent.get(parentKey).push(node);
+        });
+
+        const attachChildren = (parentId = null) => {
+            const bucket = byParent.get(parentId) || [];
+            return bucket
+                .sort((a, b) => (a.order_index ?? 0) - (b.order_index ?? 0))
+                .map((node) => {
+                    node.children = attachChildren(node.id);
+                    return node;
+                });
+        };
+
+        return attachChildren(null);
+    }
+
+    function rebuildIndex() {
+        state.nodeIndex.clear();
+        const walk = (nodes, parentId = null) => {
+            nodes.forEach((node, index) => {
+                node.order_index = index;
+                node.parent_instance_id = parentId;
+                state.nodeIndex.set(node.id, { node, parentId, siblings: nodes });
+                if (Array.isArray(node.children) && node.children.length) {
+                    walk(node.children, node.id);
+                }
+            });
+        };
+        walk(state.tree, null);
+    }
+
+    function initModuleCounters() {
+        state.moduleCounters = {};
+        state.modules.forEach((instance) => {
+            const key = instance.module;
+            const match = (instance.instance_name || '').match(/_(\d+)$/);
+            const value = match ? parseInt(match[1], 10) : 1;
+            state.moduleCounters[key] = Math.max(state.moduleCounters[key] || 0, value);
+        });
+    }
+
+    function renderPageSelector() {
+        dom.pageSelector.innerHTML = '';
+        state.pages.forEach((page) => {
+            const option = document.createElement('option');
+            option.value = page.id;
+            option.textContent = `${page.title} · ${page.slug}`;
+            if (page.id === state.currentPageId) {
+                option.selected = true;
+            }
+            dom.pageSelector.appendChild(option);
+        });
+    }
+
+    function renderModuleLibrary() {
+        const query = dom.moduleSearch.value?.toLowerCase().trim() ?? '';
+        dom.modulesList.innerHTML = '';
+
+        const filtered = state.availableModules.filter((module) => {
+            if (!query) return true;
+            const haystack = [module.name, module.label, module.category, ...(module.tags || [])]
+                .join(' ')
+                .toLowerCase();
+            return haystack.includes(query);
+        });
+
+        filtered.forEach((module) => {
+            const card = document.createElement('div');
+            card.className = 'pb-module-card';
+            card.dataset.module = module.name;
+            card.dataset.label = module.label;
+            card.dataset.description = module.description || '';
+            card.innerHTML = `
+                <strong>${module.label}</strong>
+                ${module.category ? `<small style="opacity:0.7;">${module.category}</small>` : ''}
+                ${module.description ? `<p style="opacity:0.65;font-size:0.8rem;">${module.description}</p>` : ''}
+            `;
+            dom.modulesList.appendChild(card);
+        });
+
+        dom.moduleCount.textContent = `${filtered.length} moduli`;
+
+        sortables.forEach((sortable) => sortable.destroy());
+        sortables.length = 0;
+
+        sortables.push(Sortable.create(dom.modulesList, {
+            group: { name: 'modules', pull: 'clone', revertClone: true, put: false },
+            sort: false,
+            animation: 150,
+            fallbackOnBody: true,
+            onClone: (evt) => {
+                evt.clone.style.opacity = '0.9';
+            },
+        }));
+
+        setupStageSortables();
+    }
+
+    function renderStage() {
+        dom.stage.innerHTML = '';
+        if (!state.tree.length) {
+            const empty = document.createElement('div');
+            empty.className = 'pb-stage-empty';
+            empty.innerHTML = `
+                <i class="fa-solid fa-plus-circle" style="font-size:2rem;margin-bottom:0.5rem;display:block;"></i>
+                Trascina moduli dalla libreria per iniziare a comporre la pagina.
+            `;
+            dom.stage.appendChild(empty);
+            setupStageSortables();
+            return;
+        }
+
+        state.tree.forEach((node) => {
+            dom.stage.appendChild(createNodeElement(node));
+        });
+
+        setupStageSortables();
+        highlightSelectedNode();
+        updateInlineState();
+    }
+
+    function createNodeElement(node) {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'pb-node pb-drop-target';
+        wrapper.dataset.instanceId = node.id;
+        wrapper.dataset.module = node.module;
+
+        if (node.id === state.selectedNodeId) {
+            wrapper.classList.add('is-selected');
+        }
+
+        const header = document.createElement('div');
+        header.className = 'pb-node__header';
+        header.innerHTML = `
+            <div class="pb-node__title">
+                <strong>${node.module}</strong>
+                <span>${node.instance_name}</span>
+            </div>
+            <div class="pb-node__controls">
+                <button type="button" data-action="edit"><i class="fa-solid fa-gear"></i></button>
+                <button type="button" data-action="clone"><i class="fa-solid fa-clone"></i></button>
+                <button type="button" data-action="delete"><i class="fa-solid fa-trash"></i></button>
+            </div>
+        `;
+        wrapper.appendChild(header);
+
+        const preview = document.createElement('div');
+        preview.className = 'pb-node__preview';
+        preview.dataset.instanceId = node.id;
+        preview.setAttribute('tabindex', '0');
+        preview.innerHTML = node.inlineDraft ?? node.html ?? '';
+        wrapper.appendChild(preview);
+
+        const childrenContainer = document.createElement('div');
+        childrenContainer.className = 'pb-children pb-drop-target';
+        childrenContainer.dataset.parentId = node.id;
+
+        node.children?.forEach((child) => {
+            childrenContainer.appendChild(createNodeElement(child));
+        });
+
+        wrapper.appendChild(childrenContainer);
+
+        header.addEventListener('click', () => selectNode(node.id));
+        preview.addEventListener('click', (event) => {
+            event.preventDefault();
+            if (state.inlineMode) {
+                preview.focus();
+            }
+            selectNode(node.id);
+        });
+
+        header.querySelectorAll('button').forEach((button) => {
+            button.addEventListener('click', (event) => {
+                event.stopPropagation();
+                const action = button.dataset.action;
+                if (action === 'delete') {
+                    confirmDeleteNode(node.id);
+                } else if (action === 'edit') {
+                    selectNode(node.id);
+                    focusInspector();
+                } else if (action === 'clone') {
+                    duplicateNode(node.id);
+                }
+            });
+        });
+
+        return wrapper;
+    }
+
+    function setupStageSortables() {
+        // Destroy existing stage sortables (keep library intact)
+        sortables
+            .filter((instance) => instance.el !== dom.modulesList)
+            .forEach((sortable) => sortable.destroy());
+
+        for (let i = sortables.length - 1; i >= 0; i -= 1) {
+            if (sortables[i].el !== dom.modulesList) {
+                sortables.splice(i, 1);
+            }
+        }
+
+        const targets = [dom.stage, ...dom.stage.querySelectorAll('.pb-children')];
+        targets.forEach((target) => {
+            sortables.push(Sortable.create(target, {
+                group: { name: 'modules', pull: true, put: true },
+                animation: 150,
+                fallbackOnBody: true,
+                swapThreshold: 0.65,
+                ghostClass: 'pb-drop-placeholder',
+                onAdd: handleDrop,
+                onUpdate: handleReorder,
+            }));
+        });
+    }
+
+    function handleDrop(evt) {
+        const { item, to } = evt;
+        const moduleName = item.dataset.module;
+        const label = item.dataset.label;
+        const parentAttr = to.dataset.parentId || to.dataset.parent || null;
+        const parentId = parentAttr === 'root' ? null : parentAttr ? parseNodeId(parentAttr) : null;
+        const newIndex = evt.newIndex;
+
+        if (moduleName) {
+            const newNode = createTempNode(moduleName, label, parentId, newIndex);
+            insertNode(newNode, parentId, newIndex);
+            rebuildIndex();
+            renderStage();
+            updateChangeBadges();
+            selectNode(newNode.id);
+            showToast(`${newNode.module} aggiunto allo stage`, 'success');
+        } else if (item.dataset.instanceId) {
+            const instanceId = parseNodeId(item.dataset.instanceId);
+            moveNode(instanceId, parentId, newIndex);
+            rebuildIndex();
+            renderStage();
+            persistOrder();
+            updateChangeBadges();
+            selectNode(instanceId);
+        }
+
+        if (item.parentNode) {
+            item.parentNode.removeChild(item);
+        }
+    }
+
+    function handleReorder(evt) {
+        const { item, to } = evt;
+        const parentAttr = to.dataset.parentId || to.dataset.parent || null;
+        const parentId = parentAttr === 'root' ? null : parentAttr ? parseNodeId(parentAttr) : null;
+        const instanceId = parseNodeId(item.dataset.instanceId);
+        const newIndex = evt.newIndex;
+
+        if (instanceId === null) {
+            return;
+        }
+
+        moveNode(instanceId, parentId, newIndex);
+        rebuildIndex();
+        renderStage();
+        persistOrder();
+        updateChangeBadges();
+        selectNode(instanceId);
+    }
+
+    function parseNodeId(rawId) {
+        if (!rawId) return null;
+        if (rawId.startsWith('temp-')) return rawId;
+        const parsed = parseInt(rawId, 10);
+        return Number.isNaN(parsed) ? null : parsed;
+    }
+
+    function createTempNode(moduleName, label, parentId, index) {
+        state.tempCounter += 1;
+        const tempId = `temp-${state.tempCounter}`;
+        const instanceName = generateInstanceName(moduleName);
+        const node = {
+            id: tempId,
+            module: moduleName,
+            instance_name: instanceName,
+            order_index: index ?? 0,
+            parent_instance_id: parentId ?? null,
+            html: `<div style="padding:1.25rem;border:1px dashed rgba(35,168,235,0.5);border-radius:12px;text-align:center;">Configura il modulo <strong>${label || moduleName}</strong> dal pannello a destra.</div>`,
+            config: {},
+            children: [],
+            isNew: true,
+            inlineDraft: null,
+            _configDirty: false,
+        };
+        state.changes.added.add(tempId);
+        return node;
+    }
+
+    function insertNode(node, parentId, index) {
+        const container = parentId ? state.nodeIndex.get(parentId)?.node.children : state.tree;
+        if (!container) {
+            state.tree.push(node);
+            return;
+        }
+        if (typeof index === 'number' && index >= 0 && index <= container.length) {
+            container.splice(index, 0, node);
+        } else {
+            container.push(node);
+        }
+    }
+
+    function moveNode(nodeId, newParentId, newIndex) {
+        const current = state.nodeIndex.get(nodeId);
+        if (!current) return;
+
+        const { node, siblings } = current;
+        const currentIndex = siblings.indexOf(node);
+        if (currentIndex >= 0) {
+            siblings.splice(currentIndex, 1);
+        }
+
+        const targetSiblings = newParentId ? state.nodeIndex.get(newParentId)?.node.children : state.tree;
+        if (!targetSiblings) {
+            state.tree.push(node);
+        } else if (typeof newIndex === 'number' && newIndex >= 0 && newIndex <= targetSiblings.length) {
+            targetSiblings.splice(newIndex, 0, node);
+        } else {
+            targetSiblings.push(node);
+        }
+
+        node.parent_instance_id = newParentId ?? null;
+        if (!node.isNew) {
+            state.changes.updated.add(nodeId);
+        }
+    }
+
+    function removeNode(nodeId) {
+        const current = state.nodeIndex.get(nodeId);
+        if (!current) return [];
+        const { node, siblings } = current;
+        const removedIds = [];
+
+        const collect = (target) => {
+            removedIds.push(target.id);
+            if (Array.isArray(target.children)) {
+                target.children.forEach(collect);
+            }
+        };
+        collect(node);
+
+        const index = siblings.indexOf(node);
+        if (index >= 0) {
+            siblings.splice(index, 1);
+        }
+        removedIds.forEach((id) => state.nodeIndex.delete(id));
+        return removedIds;
+    }
+
+    function duplicateNode(nodeId) {
+        const current = state.nodeIndex.get(nodeId);
+        if (!current) return;
+        const clone = resetCloneNode(deepCloneNode(current.node), current.parentId ?? null);
+        clone.instance_name = generateInstanceName(clone.module);
+
+        const siblings = current.parentId ? state.nodeIndex.get(current.parentId)?.node.children : state.tree;
+        const insertIndex = siblings ? siblings.indexOf(current.node) + 1 : state.tree.length;
+        insertNode(clone, current.parentId ?? null, insertIndex);
+        rebuildIndex();
+        renderStage();
+        updateChangeBadges();
+        selectNode(clone.id);
+    }
+
+    function resetCloneNode(node, parentId = null) {
+        state.tempCounter += 1;
+        const newId = `temp-${state.tempCounter}`;
+        node.id = newId;
+        node.isNew = true;
+        node.inlineDraft = null;
+        node.parent_instance_id = parentId;
+        node._configDirty = false;
+        state.changes.added.add(newId);
+        node.children = Array.isArray(node.children)
+            ? node.children.map((child) => resetCloneNode(deepCloneNode(child), newId))
+            : [];
+        return node;
+    }
+
+    function deepCloneNode(node) {
+        return JSON.parse(JSON.stringify(node));
+    }
+
+    function generateInstanceName(moduleName) {
+        const current = state.moduleCounters[moduleName] || 0;
+        const next = current + 1;
+        state.moduleCounters[moduleName] = next;
+        return `${moduleName}_${next}`;
+    }
+
+    function highlightSelectedNode() {
+        dom.stage.querySelectorAll('.pb-node').forEach((nodeEl) => {
+            if (parseNodeId(nodeEl.dataset.instanceId) === state.selectedNodeId) {
+                nodeEl.classList.add('is-selected');
+            } else {
+                nodeEl.classList.remove('is-selected');
+            }
+        });
+    }
+
+    function selectNode(nodeId) {
+        if (!nodeId) return;
+        const parsedId = typeof nodeId === 'string' && nodeId.startsWith('temp-') ? nodeId : parseInt(nodeId, 10);
+        if (!state.nodeIndex.has(parsedId)) {
+            return;
+        }
+        state.selectedNodeId = parsedId;
+        highlightSelectedNode();
+        updateInlineState();
+        loadInspectorForNode(parsedId);
+    }
+
+    function loadInspectorForNode(nodeId) {
+        const entry = state.nodeIndex.get(nodeId);
+        if (!entry) {
+            dom.inspectorBody.innerHTML = '<p>Seleziona un modulo per modificarlo.</p>';
+            dom.saveConfigBtn.style.display = 'none';
+            dom.inspectorLabel.textContent = '';
+            return;
+        }
+
+        const { node } = entry;
+        dom.inspectorLabel.textContent = `${node.module} · ${node.instance_name}`;
+        dom.inspectorBody.innerHTML = '<p style="opacity:0.6;">Caricamento configurazione...</p>';
+        dom.saveConfigBtn.style.display = 'none';
+
+        const formData = new FormData();
+        formData.append('action', 'get-module-config');
+        formData.append('module_name', node.module);
+        if (typeof node.id === 'number') {
+            formData.append('instance_id', node.id);
+        }
+
+        fetch('api/page_builder.php', {
+            method: 'POST',
+            body: formData,
+        })
+            .then((response) => response.json())
+            .then((data) => {
+                if (!data.success) {
+                    throw new Error(data.error || 'Errore caricamento configurazione');
+                }
+                inspectorState = {
+                    nodeId,
+                    config: data.config || {},
+                    manifest: data.manifest || {},
+                };
+                renderInspectorForm(node, inspectorState);
+            })
+            .catch((error) => {
+                dom.inspectorBody.innerHTML = `<p style="color:#ff9f9f;">${error.message}</p>`;
+            });
+    }
+
+    function renderInspectorForm(node, inspector) {
+        const container = document.createElement('div');
+        container.className = 'pb-form';
+
+        // Instance name
+        const nameGroup = document.createElement('div');
+        nameGroup.className = 'pb-form-group';
+        nameGroup.innerHTML = `
+            <label>Nome istanza</label>
+            <input type="text" data-field="instance_name" value="${node.instance_name}">
+        `;
+        nameGroup.querySelector('input').addEventListener('input', (event) => {
+            node.instance_name = event.target.value;
+            node._configDirty = true;
+            state.changes.updated.add(node.id);
+            updateChangeBadges();
+        });
+        container.appendChild(nameGroup);
+
+        const schema = inspector.manifest?.ui_schema || {};
+        if (Object.keys(schema).length === 0) {
+            const jsonGroup = document.createElement('div');
+            jsonGroup.className = 'pb-form-group';
+            jsonGroup.innerHTML = `
+                <label>Configurazione JSON</label>
+                <textarea data-field="json">${JSON.stringify(inspector.config, null, 2)}</textarea>
+            `;
+            jsonGroup.querySelector('textarea').addEventListener('input', () => {
+                node._configDirty = true;
+                state.changes.updated.add(node.id);
+                updateChangeBadges();
+            });
+            container.appendChild(jsonGroup);
+        } else {
+            Object.entries(schema).forEach(([path, field]) => {
+                const formGroup = document.createElement('div');
+                formGroup.className = 'pb-form-group';
+                const label = document.createElement('label');
+                label.textContent = field.label || path;
+                if (field.required) {
+                    label.innerHTML += ' <span style="color:#ff9f9f;">*</span>';
+                }
+                formGroup.appendChild(label);
+
+                const value = getByPath(inspector.config, path);
+                let input;
+                switch (field.type) {
+                    case 'textarea':
+                        input = document.createElement('textarea');
+                        input.value = value ?? '';
+                        break;
+                    case 'select':
+                        input = document.createElement('select');
+                        (field.options || []).forEach((option) => {
+                            const opt = document.createElement('option');
+                            opt.value = option.value;
+                            opt.textContent = option.label;
+                            if (option.value === value) opt.selected = true;
+                            input.appendChild(opt);
+                        });
+                        break;
+                    case 'boolean':
+                        input = document.createElement('input');
+                        input.type = 'checkbox';
+                        input.checked = Boolean(value);
+                        break;
+                    case 'color':
+                        input = document.createElement('input');
+                        input.type = 'color';
+                        input.value = value || '#ffffff';
+                        break;
+                    case 'repeater':
+                        input = document.createElement('textarea');
+                        input.value = Array.isArray(value) ? JSON.stringify(value, null, 2) : '';
+                        input.setAttribute('data-repeater', 'true');
+                        break;
+                    default:
+                        input = document.createElement('input');
+                        input.type = field.type === 'number' ? 'number' : 'text';
+                        input.value = value ?? '';
+                        break;
+                }
+                input.dataset.path = path;
+
+                input.addEventListener(field.type === 'boolean' ? 'change' : 'input', (event) => {
+                    const target = event.target;
+                    let nextValue;
+                    if (target.type === 'checkbox') {
+                        nextValue = target.checked;
+                    } else if (target.dataset.repeater === 'true') {
+                        try {
+                            nextValue = JSON.parse(target.value || '[]');
+                        } catch (error) {
+                            nextValue = [];
+                        }
+                    } else {
+                        nextValue = target.value;
+                    }
+                    setByPath(inspector.config, path, nextValue);
+                    node._configDirty = true;
+                    state.changes.updated.add(node.id);
+                    updateChangeBadges();
+                });
+
+                formGroup.appendChild(input);
+                container.appendChild(formGroup);
+            });
+        }
+
+        dom.inspectorBody.innerHTML = '';
+        dom.inspectorBody.appendChild(container);
+        dom.saveConfigBtn.style.display = 'block';
+        dom.cancelInlineBtn.style.display = node.inlineDraft ? 'block' : 'none';
+    }
+
+    function getByPath(obj, path) {
+        if (!obj) return undefined;
+        const parts = path.split('.');
+        return parts.reduce((acc, part) => (acc && Object.prototype.hasOwnProperty.call(acc, part) ? acc[part] : undefined), obj);
+    }
+
+    function setByPath(obj, path, value) {
+        const parts = path.split('.');
+        let current = obj;
+        parts.forEach((part, index) => {
+            if (index === parts.length - 1) {
+                current[part] = value;
+            } else {
+                if (!current[part] || typeof current[part] !== 'object') {
+                    current[part] = {};
+                }
+                current = current[part];
+            }
+        });
+    }
+
+    function persistCurrentInspector() {
+        if (!inspectorState) return;
+        const entry = state.nodeIndex.get(inspectorState.nodeId);
+        if (!entry) return;
+        const { node } = entry;
+
+        let configPayload = {};
+        if (dom.inspectorBody.querySelector('textarea[data-field="json"]')) {
+            try {
+                configPayload = JSON.parse(dom.inspectorBody.querySelector('textarea[data-field="json"]').value || '{}');
+            } catch (error) {
+                showToast('JSON non valido', 'error');
+                return;
+            }
+        } else {
+            configPayload = inspectorState.config || {};
+        }
+
+        if (node.inlineDraft !== null) {
+            configPayload.__inline_html = node.inlineDraft;
+        }
+
+        const payload = {
+            action: 'save-instance',
+            page_id: state.currentPageId,
+            module_name: node.module,
+            instance_name: node.instance_name,
+            config: configPayload,
+            order_index: node.order_index || 0,
+            parent_instance_id: node.parent_instance_id,
+        };
+
+        if (typeof node.id === 'number') {
+            payload.instance_id = node.id;
+        } else {
+            payload.instance_id = 'temp';
+        }
+
+        fetch('api/page_builder.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+        })
+            .then((response) => response.json())
+            .then((data) => {
+                if (!data.success) {
+                    throw new Error(data.error || 'Errore durante il salvataggio');
+                }
+                applySaveResult(node, data.instance);
+                showToast('Modulo salvato con successo', 'success');
+            })
+            .catch((error) => {
+                showToast(error.message, 'error');
+            });
+    }
+
+    function applySaveResult(node, result) {
+        const previousId = node.id;
+        node.instance_name = result.instance_name;
+        node.html = result.html;
+        node.config = result.config || {};
+        node.inlineDraft = null;
+        node._configDirty = false;
+        dom.cancelInlineBtn.style.display = 'none';
+
+        if (typeof previousId === 'string' && previousId.startsWith('temp-')) {
+            state.changes.added.delete(previousId);
+            state.changes.updated.delete(previousId);
+            node.id = result.id;
+            node.isNew = false;
+            state.selectedNodeId = node.id;
+        }
+        state.changes.updated.delete(node.id);
+
+        rebuildIndex();
+        renderStage();
+        updateChangeBadges();
+        loadInspectorForNode(node.id);
+        persistOrder();
+    }
+
+    function persistOrder() {
+        const updates = [];
+        const walk = (nodes, parentId = null) => {
+            nodes.forEach((node, index) => {
+                node.order_index = index;
+                node.parent_instance_id = parentId;
+                if (typeof node.id === 'number') {
+                    updates.push({
+                        id: node.id,
+                        order_index: index,
+                        parent_instance_id: parentId,
+                    });
+                }
+                if (node.children?.length) {
+                    walk(node.children, typeof node.id === 'number' ? node.id : null);
+                }
+            });
+        };
+        walk(state.tree, null);
+
+        if (!updates.length) {
+            return;
+        }
+
+        fetch('api/page_builder.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ action: 'update-order', updates }),
+        }).catch(() => {});
+    }
+
+    function confirmDeleteNode(nodeId) {
+        const entry = state.nodeIndex.get(nodeId);
+        if (!entry) return;
+        if (!window.confirm('Eliminare questo modulo e i suoi elementi annidati?')) {
+            return;
+        }
+
+        if (typeof nodeId === 'number') {
+            fetch('api/page_builder.php', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ action: 'delete-instance', instance_id: nodeId }),
+            })
+                .then((response) => response.json())
+                .then((data) => {
+                    if (!data.success) {
+                        throw new Error(data.error || 'Errore durante l\'eliminazione');
+                    }
+                    const removedIds = removeNode(nodeId);
+                    rebuildIndex();
+                    removedIds.forEach((id) => {
+                        state.changes.added.delete(id);
+                        state.changes.updated.delete(id);
+                        if (typeof id === 'number') {
+                            state.changes.deleted.add(id);
+                        }
+                    });
+                    renderStage();
+                    updateChangeBadges();
+                    dom.inspectorBody.innerHTML = '<p>Modulo eliminato. Seleziona un altro elemento.</p>';
+                    dom.saveConfigBtn.style.display = 'none';
+                    showToast('Modulo eliminato', 'success');
+                    state.selectedNodeId = null;
+                })
+                .catch((error) => showToast(error.message, 'error'));
+        } else {
+            const removedIds = removeNode(nodeId);
+            rebuildIndex();
+            removedIds.forEach((id) => {
+                state.changes.added.delete(id);
+                state.changes.updated.delete(id);
+            });
+            renderStage();
+            updateChangeBadges();
+            dom.inspectorBody.innerHTML = '<p>Modulo eliminato.</p>';
+            dom.saveConfigBtn.style.display = 'none';
+            state.selectedNodeId = null;
+        }
+    }
+
+    function toggleInlineMode() {
+        state.inlineMode = !state.inlineMode;
+        if (state.inlineMode) {
+            dom.inlineToggle.classList.add('is-active');
+            showToast('Modalità inline attiva. Clicca sul contenuto per modificarlo.', 'success');
+        } else {
+            dom.inlineToggle.classList.remove('is-active');
+            cancelInlineDraft();
+        }
+        updateInlineState();
+    }
+
+    function updateInlineState() {
+        dom.stage.querySelectorAll('.pb-node__preview').forEach((preview) => {
+            const nodeId = parseNodeId(preview.dataset.instanceId);
+            if (state.inlineMode && nodeId === state.selectedNodeId) {
+                preview.contentEditable = 'true';
+                preview.addEventListener('focus', handleInlineFocus);
+                preview.addEventListener('input', handleInlineInput);
+            } else {
+                preview.contentEditable = 'false';
+                preview.removeEventListener('focus', handleInlineFocus);
+                preview.removeEventListener('input', handleInlineInput);
+            }
+        });
+    }
+
+    function handleInlineFocus(event) {
+        const nodeId = parseNodeId(event.currentTarget.dataset.instanceId);
+        const entry = state.nodeIndex.get(nodeId);
+        if (!entry) return;
+        const { node } = entry;
+        if (node.inlineDraft === null) {
+            node.inlineDraft = node.html;
+        }
+        dom.cancelInlineBtn.style.display = 'block';
+    }
+
+    function handleInlineInput(event) {
+        const nodeId = parseNodeId(event.currentTarget.dataset.instanceId);
+        const entry = state.nodeIndex.get(nodeId);
+        if (!entry) return;
+        const { node } = entry;
+        node.inlineDraft = event.currentTarget.innerHTML;
+        state.changes.updated.add(nodeId);
+        updateChangeBadges();
+    }
+
+    function cancelInlineDraft() {
+        if (state.selectedNodeId === null) return;
+        const entry = state.nodeIndex.get(state.selectedNodeId);
+        if (!entry) return;
+        const { node } = entry;
+        if (node.inlineDraft !== null) {
+            node.inlineDraft = null;
+            renderStage();
+            loadInspectorForNode(node.id);
+        }
+        if (!node._configDirty) {
+            state.changes.updated.delete(node.id);
+            updateChangeBadges();
+        }
+        dom.cancelInlineBtn.style.display = 'none';
+    }
+
+    function updateStageHeader() {
+        if (!state.currentPage) {
+            dom.stageName.textContent = 'Nessuna pagina selezionata';
+            dom.stageSlug.textContent = '';
+            return;
+        }
+        const status = state.currentPage.status ?? 'draft';
+        dom.stageName.textContent = state.currentPage.title;
+        dom.stageSlug.textContent = `Slug: ${state.currentPage.slug} · Stato: ${status}`;
+    }
+
+    function updateChangeBadges() {
+        dom.changeBadges.innerHTML = '';
+        const entries = [
+            { label: 'Nuovi', set: state.changes.added, icon: 'fa-plus', tone: 'success' },
+            { label: 'Modificati', set: state.changes.updated, icon: 'fa-pen', tone: 'warning' },
+            { label: 'Eliminati', set: state.changes.deleted, icon: 'fa-trash', tone: 'danger' },
+        ];
+        entries.forEach((entry) => {
+            if (entry.set.size === 0) return;
+            const badge = document.createElement('span');
+            badge.className = 'pb-badge';
+            badge.innerHTML = `<span class="pb-status-dot ${entry.tone}"></span><i class="fa-solid ${entry.icon}"></i> ${entry.label}: ${entry.set.size}`;
+            dom.changeBadges.appendChild(badge);
+        });
+    }
+
+    function showToast(message, type = 'info') {
+        if (!dom.toast) return;
+        dom.toast.textContent = '';
+        dom.toast.className = 'pb-toast';
+        if (type === 'error') dom.toast.classList.add('pb-toast--error');
+        if (type === 'success') dom.toast.classList.add('pb-toast--success');
+        dom.toast.innerHTML = `<i class="fa-solid ${type === 'error' ? 'fa-circle-xmark' : 'fa-circle-check'}"></i> ${message}`;
+        dom.toast.style.display = 'flex';
+        clearTimeout(dom.toast._timeout);
+        dom.toast._timeout = setTimeout(() => {
+            dom.toast.style.display = 'none';
+        }, 3000);
+    }
+
+    function focusInspector() {
+        dom.inspectorBody?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+
+    function previewCurrentPage() {
+        if (!state.currentPageId) return;
+        window.open(`../index.php?id_pagina=${state.currentPageId}`, '_blank');
+    }
+
+    function loadPage(pageId) {
+        fetch(`api/page_builder.php?action=page&page_id=${pageId}`)
+            .then((response) => response.json())
+            .then((data) => {
+                if (!data.success) {
+                    throw new Error(data.error || 'Errore caricamento pagina');
+                }
+                state.currentPageId = pageId;
+                state.currentPage = data.page;
+                state.modules = (data.instances || []).map((instance) => ({
+                    id: instance.id,
+                    module: instance.module,
+                    instance_name: instance.instance_name,
+                    order_index: instance.order_index,
+                    parent_instance_id: instance.parent_instance_id ?? null,
+                    html: instance.html,
+                    config: instance.config || {},
+                }));
+                state.tree = buildTree(state.modules);
+                rebuildIndex();
+                initModuleCounters();
+                state.selectedNodeId = null;
+                inspectorState = null;
+                dom.inspectorBody.innerHTML = '<p>Seleziona un modulo per modificarlo.</p>';
+                dom.saveConfigBtn.style.display = 'none';
+                state.changes.added.clear();
+                state.changes.updated.clear();
+                state.changes.deleted.clear();
+                renderPageSelector();
+                updateStageHeader();
+                renderStage();
+                updateChangeBadges();
+            })
+            .catch((error) => {
+                showToast(error.message, 'error');
+            });
+    }
+
+    function handleCreatePage() {
+        const title = window.prompt('Titolo nuova pagina');
+        if (!title) return;
+        const slug = window.prompt('Slug (facoltativo, verrà generato dal titolo se vuoto)', '');
+        fetch('api/page_builder.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ action: 'create-page', title, slug }),
+        })
+            .then((response) => response.json())
+            .then((data) => {
+                if (!data.success) {
+                    throw new Error(data.error || 'Errore creazione pagina');
+                }
+                state.pages.push(data.page);
+                renderPageSelector();
+                loadPage(data.page.id);
+                showToast('Pagina creata', 'success');
+            })
+            .catch((error) => showToast(error.message, 'error'));
+    }
+
+    function handleRenamePage() {
+        if (!state.currentPageId) return;
+        const current = state.pages.find((page) => page.id === state.currentPageId);
+        const title = window.prompt('Nuovo titolo pagina', current?.title || '');
+        if (!title) return;
+        const slug = window.prompt('Slug (lascia vuoto per auto-generare)', current?.slug || '');
+        fetch('api/page_builder.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ action: 'update-page', page_id: state.currentPageId, title, slug }),
+        })
+            .then((response) => response.json())
+            .then((data) => {
+                if (!data.success) {
+                    throw new Error(data.error || 'Errore aggiornamento pagina');
+                }
+                const pageIndex = state.pages.findIndex((page) => page.id === state.currentPageId);
+                if (pageIndex >= 0) {
+                    state.pages[pageIndex] = { ...state.pages[pageIndex], ...data.page };
+                }
+                state.currentPage = { ...state.currentPage, ...data.page };
+                renderPageSelector();
+                updateStageHeader();
+                showToast('Pagina aggiornata', 'success');
+            })
+            .catch((error) => showToast(error.message, 'error'));
+    }
+
+    function handleDeletePage() {
+        if (!state.currentPageId) return;
+        if (!window.confirm('Eliminare definitivamente questa pagina?')) {
+            return;
+        }
+        fetch('api/page_builder.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ action: 'delete-page', page_id: state.currentPageId }),
+        })
+            .then((response) => response.json())
+            .then((data) => {
+                if (!data.success) {
+                    throw new Error(data.error || 'Errore eliminazione pagina');
+                }
+                state.pages = state.pages.filter((page) => page.id !== state.currentPageId);
+                state.currentPageId = state.pages[0]?.id ?? null;
+                if (state.currentPageId) {
+                    loadPage(state.currentPageId);
+                } else {
+                    state.currentPage = null;
+                    state.tree = [];
+                    state.modules = [];
+                    renderPageSelector();
+                    renderStage();
+                    updateStageHeader();
+                }
+                showToast('Pagina eliminata', 'success');
+            })
+            .catch((error) => showToast(error.message, 'error'));
+    }
+
+    init();
+})();

--- a/admin/page-builder.php
+++ b/admin/page-builder.php
@@ -1,7 +1,5 @@
 <?php
-/**
- * Page Builder - Interfaccia amministrativa
- */
+declare(strict_types=1);
 
 require_once __DIR__ . '/../config/database.php';
 require_once __DIR__ . '/../core/ModuleRenderer.php';
@@ -12,7 +10,7 @@ $renderer = new ModuleRenderer($db);
 
 $pageId = (int)($_GET['page_id'] ?? 0);
 
-$pagesStmt = $db->query('SELECT id, title, slug FROM pages ORDER BY title');
+$pagesStmt = $db->query('SELECT id, title, slug, status FROM pages ORDER BY title');
 $pages = $pagesStmt->fetchAll() ?: [];
 
 if ($pageId <= 0 && count($pages) > 0) {
@@ -21,7 +19,7 @@ if ($pageId <= 0 && count($pages) > 0) {
 
 $currentPage = null;
 if ($pageId > 0) {
-    $pageStmt = $db->prepare('SELECT id, title, slug FROM pages WHERE id = ?');
+    $pageStmt = $db->prepare('SELECT id, title, slug, status FROM pages WHERE id = ?');
     $pageStmt->execute([$pageId]);
     $currentPage = $pageStmt->fetch();
 }
@@ -42,15 +40,18 @@ while ($module = $modulesStmt->fetch()) {
 
 $instances = [];
 if ($pageId > 0) {
-    $instancesStmt = $db->prepare('SELECT id, module_name, instance_name, config, order_index, is_active FROM module_instances WHERE page_id = ? ORDER BY order_index');
+    $instancesStmt = $db->prepare('SELECT id, module_name, instance_name, config, order_index, parent_instance_id, is_active FROM module_instances WHERE page_id = ? ORDER BY order_index');
     $instancesStmt->execute([$pageId]);
+
     while ($instance = $instancesStmt->fetch()) {
         if ((int)$instance['is_active'] !== 1) {
             continue;
         }
+
         $config = json_decode($instance['config'], true) ?? [];
         $merged = $renderer->mergeConfigWithDefaults($instance['module_name'], $config);
         $html = '';
+
         try {
             $html = $renderer->renderModule($instance['module_name'], $merged);
         } catch (Throwable $exception) {
@@ -62,16 +63,21 @@ if ($pageId > 0) {
             'module' => $instance['module_name'],
             'instance_name' => $instance['instance_name'],
             'order_index' => (int)$instance['order_index'],
+            'parent_instance_id' => $instance['parent_instance_id'] !== null ? (int)$instance['parent_instance_id'] : null,
             'html' => $html,
+            'config' => $merged,
         ];
     }
 }
+
+$moduleTree = $renderer->buildModuleInstanceTree($instances);
 
 $initialPayload = [
     'pages' => $pages,
     'currentPageId' => $pageId,
     'currentPage' => $currentPage,
     'moduleInstances' => $instances,
+    'moduleTree' => $moduleTree,
     'availableModules' => $availableModules,
 ];
 
@@ -82,1592 +88,513 @@ $initialJson = htmlspecialchars(json_encode($initialPayload, JSON_UNESCAPED_UNIC
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Page Builder - Bologna Marathon</title>
-    
-    <!-- CSS: usa core CSS in admin per maggiore stabilità -->
+    <title>Builder Pagine · Bologna Marathon</title>
     <link rel="stylesheet" href="../assets/css/core/variables.css">
     <link rel="stylesheet" href="../assets/css/core/reset.css">
     <link rel="stylesheet" href="../assets/css/core/typography.css">
     <link rel="stylesheet" href="../assets/css/core/fonts.css">
-    
-    <!-- Font Awesome per icone -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <style>
-        .page-builder {
-            display: grid;
-            grid-template-columns: 300px 1fr 300px;
-            height: 100vh;
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        :root {
+            --pb-bg: #0d1117;
+            --pb-surface: rgba(255, 255, 255, 0.04);
+            --pb-surface-strong: rgba(255, 255, 255, 0.08);
+            --pb-border: rgba(255, 255, 255, 0.1);
+            --pb-text: #d6d7dc;
+            --pb-text-strong: #ffffff;
+            --pb-accent: #23a8eb;
+            --pb-accent-soft: rgba(35, 168, 235, 0.15);
+            --pb-danger: #ff5678;
+            --pb-success: #2ecc71;
+            --pb-warning: #f1c40f;
+            --pb-radius: 18px;
+            --pb-sidebar-width: 260px;
+            --pb-inspector-width: 320px;
         }
-        
-        .sidebar {
-            background: #ffffff;
-            border-right: 1px solid #dee2e6;
-            padding: 1rem;
-            overflow-y: auto;
-            overflow-x: hidden;
-            box-shadow: 2px 0 4px rgba(0,0,0,0.1);
-            max-width: 300px;
-            box-sizing: border-box;
-        }
-        
-        .sidebar h3 {
-            color: #2c3e50;
-            margin-bottom: 1rem;
-            font-size: 1.1rem;
-            font-weight: 600;
-            border-bottom: 2px solid #007bff;
-            padding-bottom: 0.5rem;
-        }
-        
-        .sidebar p {
-            color: #495057;
-            font-size: 0.9rem;
-            margin-bottom: 0.5rem;
-        }
-        
-        .main-content {
+
+        body {
+            background: var(--pb-bg);
+            color: var(--pb-text);
+            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            min-height: 100vh;
+            margin: 0;
             display: flex;
             flex-direction: column;
-            background: white;
         }
-        
-        .page-canvas {
+
+        .pb-shell {
+            display: flex;
+            flex-direction: column;
+            min-height: 100vh;
+        }
+
+        .pb-header {
+            padding: 1.5rem 2rem 1rem;
+            display: grid;
+            grid-template-columns: 1fr auto;
+            gap: 1.5rem;
+            align-items: end;
+        }
+
+        .pb-header__titles h1 {
+            font-size: 1.75rem;
+            color: var(--pb-text-strong);
+            margin-bottom: 0.35rem;
+        }
+
+        .pb-header__titles p {
+            margin: 0;
+            color: rgba(255, 255, 255, 0.65);
+            font-size: 0.95rem;
+        }
+
+        .pb-header__actions {
+            display: flex;
+            flex-direction: column;
+            gap: 0.75rem;
+            align-items: flex-end;
+        }
+
+        .pb-page-switcher {
+            display: flex;
+            gap: 0.75rem;
+            align-items: center;
+        }
+
+        .pb-page-switcher select {
+            background: var(--pb-surface);
+            border: 1px solid var(--pb-border);
+            color: var(--pb-text-strong);
+            padding: 0.65rem 0.85rem;
+            border-radius: 10px;
+            min-width: 240px;
+            font-size: 0.95rem;
+        }
+
+        .pb-page-switcher button {
+            border: none;
+            background: var(--pb-surface-strong);
+            color: var(--pb-text);
+            padding: 0.6rem 0.85rem;
+            border-radius: 10px;
+            cursor: pointer;
+            transition: background 0.2s ease;
+        }
+
+        .pb-page-switcher button:hover {
+            background: var(--pb-accent-soft);
+            color: var(--pb-text-strong);
+        }
+
+        .pb-badges {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .pb-badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            padding: 0.45rem 0.75rem;
+            border-radius: 999px;
+            background: rgba(255, 255, 255, 0.08);
+            font-size: 0.8rem;
+            letter-spacing: 0.02em;
+        }
+
+        .pb-badge i { font-size: 0.85rem; }
+
+        .pb-main {
             flex: 1;
-            padding: 2rem;
-            overflow-y: auto;
-            overflow-x: hidden;
-            background: #f5f5f5;
-            max-width: 100%;
-            box-sizing: border-box;
+            display: grid;
+            grid-template-columns: var(--pb-sidebar-width) 1fr var(--pb-inspector-width);
+            gap: 1.25rem;
+            padding: 0 2rem 2rem;
         }
-        
-        .module-instance {
-            background: white;
-            border: 1px solid #e9ecef;
-            border-radius: 8px;
-            margin-bottom: 1rem;
-            position: relative;
-            transition: all 0.3s ease;
-            overflow: hidden;
-            max-width: 100%;
-            box-sizing: border-box;
+
+        .pb-sidebar,
+        .pb-inspector {
+            background: var(--pb-surface);
+            border: 1px solid var(--pb-border);
+            border-radius: var(--pb-radius);
+            padding: 1.25rem;
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+            backdrop-filter: blur(12px);
         }
-        
-        .module-instance:hover {
-            border-color: #007bff;
-            box-shadow: 0 4px 12px rgba(0,123,255,0.15);
-        }
-        
-        .module-instance:hover .module-header {
-            opacity: 1;
-            transform: translateY(0);
-        }
-        
-        .module-header {
-            background: rgba(0,123,255,0.9);
-            color: white;
-            padding: 0.5rem 1rem;
+
+        .pb-sidebar__header,
+        .pb-inspector__header {
             display: flex;
             justify-content: space-between;
             align-items: center;
-            cursor: move;
+            color: var(--pb-text-strong);
+        }
+
+        .pb-module-search {
+            position: relative;
+        }
+
+        .pb-module-search input {
+            width: 100%;
+            background: rgba(255, 255, 255, 0.05);
+            border: 1px solid var(--pb-border);
+            border-radius: 10px;
+            padding: 0.6rem 0.85rem 0.6rem 2.25rem;
+            color: var(--pb-text-strong);
+            font-size: 0.9rem;
+        }
+
+        .pb-module-search i {
             position: absolute;
-            top: 0;
-            left: 0;
-            right: 0;
-            z-index: 10;
-            opacity: 0;
-            transform: translateY(-100%);
-            transition: all 0.3s ease;
-            backdrop-filter: blur(10px);
-            z-index: 1000000;
+            left: 0.75rem;
+            top: 50%;
+            transform: translateY(-50%);
+            color: rgba(255, 255, 255, 0.4);
         }
-        
-        .module-content {
-            padding: 0;
-            min-height: 80px;
-            max-width: 100%;
+
+        .pb-modules__list {
+            flex: 1;
+            overflow-y: auto;
+            padding-right: 0.5rem;
+            display: flex;
+            flex-direction: column;
+            gap: 0.75rem;
+        }
+
+        .pb-module-card {
+            background: rgba(255, 255, 255, 0.05);
+            border: 1px dashed transparent;
+            border-radius: 14px;
+            padding: 0.9rem 1rem;
+            display: flex;
+            flex-direction: column;
+            gap: 0.35rem;
+            cursor: grab;
+            transition: transform 0.2s ease, border 0.2s ease, background 0.2s ease;
+        }
+
+        .pb-module-card:hover {
+            border-color: rgba(35, 168, 235, 0.5);
+            background: rgba(35, 168, 235, 0.08);
+            transform: translateX(4px);
+        }
+
+        .pb-module-card strong {
+            color: var(--pb-text-strong);
+        }
+
+        .pb-stage-panel {
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+        }
+
+        .pb-stage-toolbar {
+            background: var(--pb-surface);
+            border: 1px solid var(--pb-border);
+            border-radius: var(--pb-radius);
+            padding: 0.75rem 1rem;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 1rem;
+        }
+
+        .pb-stage-toolbar__actions {
+            display: flex;
+            gap: 0.75rem;
+            align-items: center;
+        }
+
+        .pb-stage-toolbar__actions button {
+            background: rgba(255, 255, 255, 0.05);
+            border: 1px solid var(--pb-border);
+            color: var(--pb-text);
+            padding: 0.5rem 0.85rem;
+            border-radius: 10px;
+            cursor: pointer;
+        }
+
+        .pb-stage-toolbar__actions button.is-active {
+            background: var(--pb-accent-soft);
+            color: var(--pb-text-strong);
+            border-color: rgba(35, 168, 235, 0.6);
+        }
+
+        .pb-stage {
+            flex: 1;
+            background: rgba(13, 17, 23, 0.35);
+            border: 1px solid rgba(255, 255, 255, 0.06);
+            border-radius: var(--pb-radius);
+            padding: 1.5rem;
+            overflow-y: auto;
+            min-height: 60vh;
+        }
+
+        .pb-stage-empty {
+            border: 1px dashed rgba(255, 255, 255, 0.2);
+            border-radius: var(--pb-radius);
+            padding: 3rem;
+            text-align: center;
+            color: rgba(255, 255, 255, 0.55);
+        }
+
+        .pb-node {
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            border-radius: 18px;
+            margin-bottom: 1.25rem;
+            background: rgba(13, 17, 23, 0.65);
             overflow: hidden;
+            position: relative;
         }
-        
-        .module-content * {
-            max-width: 100% !important;
-            box-sizing: border-box !important;
+
+        .pb-node__header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 0.75rem 1rem;
+            background: rgba(255, 255, 255, 0.04);
+            border-bottom: 1px solid rgba(255, 255, 255, 0.05);
         }
-        
-        .module-controls {
+
+        .pb-node__title {
+            display: flex;
+            flex-direction: column;
+            gap: 0.2rem;
+        }
+
+        .pb-node__title span {
+            font-size: 0.75rem;
+            color: rgba(255, 255, 255, 0.5);
+        }
+
+        .pb-node__controls {
             display: flex;
             gap: 0.5rem;
         }
-        
-        .btn-small {
-            padding: 0.5rem 0.75rem;
-            font-size: 0.85rem;
-            border: none;
-            border-radius: 6px;
+
+        .pb-node__controls button {
+            background: rgba(255, 255, 255, 0.06);
+            border: 1px solid transparent;
+            color: var(--pb-text);
+            padding: 0.35rem 0.6rem;
+            border-radius: 8px;
             cursor: pointer;
-            transition: all 0.3s ease;
-            font-weight: 500;
-            text-decoration: none;
-            display: inline-block;
         }
-        
-        .btn-edit { background: #28a745; color: white; }
-        .btn-delete { background: #dc3545; color: white; }
-        .btn-preview { background: #007bff; color: white; }
-        
-        .btn-small:hover { 
-            opacity: 0.9; 
-            transform: translateY(-1px);
-            box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+
+        .pb-node__controls button:hover {
+            border-color: rgba(35, 168, 235, 0.6);
+            color: var(--pb-text-strong);
         }
-        
-        .module-list {
-            margin-bottom: 2rem;
-        }
-        
-        .module-item {
-            background: white;
-            border: 1px solid #dee2e6;
-            border-radius: 6px;
-            padding: 0.75rem;
-            margin-bottom: 0.5rem;
-            cursor: pointer;
-            transition: all 0.3s ease;
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            color: #495057;
-            font-weight: 500;
-        }
-        
-        .module-item:hover {
-            background: #007bff;
-            color: white;
-            border-color: #007bff;
-            transform: translateX(4px);
-            box-shadow: 0 2px 8px rgba(0,123,255,0.3);
-        }
-        
-        .module-item i {
-            color: #6c757d;
-            transition: color 0.3s ease;
-        }
-        
-        .module-item:hover i {
-            color: white;
-        }
-        
-        .config-panel {
-            background: #ffffff;
-            border-left: 1px solid #dee2e6;
+
+        .pb-node__preview {
             padding: 1rem;
+            background: rgba(13, 17, 23, 0.85);
+        }
+
+        .pb-node__preview[contenteditable="true"] {
+            outline: 2px dashed rgba(35, 168, 235, 0.75);
+            outline-offset: 6px;
+        }
+
+        .pb-children {
+            padding: 1rem 1rem 0.5rem 1.5rem;
+            display: flex;
+            flex-direction: column;
+            gap: 0.75rem;
+        }
+
+        .pb-drop-target {
+            min-height: 30px;
+        }
+
+        .pb-drop-placeholder {
+            border: 2px dashed rgba(35, 168, 235, 0.75);
+            border-radius: 12px;
+            height: 60px;
+            margin: 0.5rem 0;
+        }
+
+        .pb-node.is-selected {
+            border-color: rgba(35, 168, 235, 0.8);
+            box-shadow: 0 0 0 2px rgba(35, 168, 235, 0.2);
+        }
+
+        .pb-inspector__body {
+            flex: 1;
             overflow-y: auto;
-            overflow-x: hidden;
-            box-shadow: -2px 0 4px rgba(0,0,0,0.1);
-            max-width: 300px;
-            box-sizing: border-box;
+            padding-right: 0.5rem;
         }
-        
-        .config-panel h3 {
-            color: #2c3e50;
-            margin-bottom: 1rem;
-            font-size: 1.1rem;
-            font-weight: 600;
-            border-bottom: 2px solid #007bff;
-            padding-bottom: 0.5rem;
+
+        .pb-form-group {
+            display: flex;
+            flex-direction: column;
+            gap: 0.35rem;
+            margin-bottom: 0.85rem;
         }
-        
-        .form-group {
-            margin-bottom: 1rem;
+
+        .pb-form-group label {
+            font-size: 0.85rem;
+            color: rgba(255, 255, 255, 0.75);
         }
-        
-        .form-group label {
-            display: block;
-            margin-bottom: 0.25rem;
-            font-weight: 600;
-            color: #2c3e50;
+
+        .pb-form-group input,
+        .pb-form-group textarea,
+        .pb-form-group select {
+            background: rgba(255, 255, 255, 0.05);
+            border: 1px solid var(--pb-border);
+            border-radius: 10px;
+            color: var(--pb-text-strong);
+            padding: 0.6rem 0.8rem;
             font-size: 0.9rem;
         }
-        
-        .form-group input,
-        .form-group select,
-        .form-group textarea {
-            width: 100%;
-            padding: 0.75rem;
-            border: 1px solid #ced4da;
-            border-radius: 6px;
-            font-size: 0.9rem;
-            background: white;
-            color: #495057;
-            transition: all 0.3s ease;
-        }
-        
-        .form-group input:focus,
-        .form-group select:focus,
-        .form-group textarea:focus {
-            outline: none;
-            border-color: #007bff;
-            box-shadow: 0 0 0 3px rgba(0,123,255,0.1);
-        }
-        
-        .form-group textarea {
-            height: 80px;
+
+        .pb-form-group textarea {
+            min-height: 90px;
             resize: vertical;
         }
-        
-        .drag-placeholder {
-            border: 2px dashed #007bff;
-            background: rgba(0,123,255,0.1);
-            border-radius: 8px;
-            height: 100px;
-            margin-bottom: 1rem;
+
+        .pb-inspector__footer {
             display: flex;
-            align-items: center;
-            justify-content: center;
-            color: #007bff;
-            font-weight: 500;
+            flex-direction: column;
+            gap: 0.75rem;
+            margin-top: auto;
         }
-        
-        .selected-instance {
-            border-color: #28a745 !important;
-            box-shadow: 0 0 0 3px rgba(40,167,69,0.25);
-        }
-        
-        .empty-state {
-            text-align: center;
-            padding: 3rem;
-            color: #6c757d;
-        }
-        
-        .empty-state i {
-            font-size: 3rem;
-            margin-bottom: 1rem;
-            opacity: 0.5;
-        }
-        
-        .page-selector {
-            margin-bottom: 1rem;
-        }
-        
-        .page-selector select {
-            width: 100%;
-            padding: 0.75rem;
-            border: 1px solid #ced4da;
-            border-radius: 6px;
-            font-size: 0.9rem;
-            background: white;
-            color: #495057;
-            font-weight: 500;
-        }
-        
-        .page-selector select:focus {
-            outline: none;
-            border-color: #007bff;
-            box-shadow: 0 0 0 3px rgba(0,123,255,0.1);
-        }
-        
-        .preview-modal {
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background: rgba(0,0,0,0.8);
-            display: none;
-            align-items: center;
-            justify-content: center;
-            z-index: 1000;
-        }
-        
-        .preview-content {
-            background: white;
-            border-radius: 8px;
-            padding: 2rem;
-            max-width: 80%;
-            max-height: 80%;
-            overflow: auto;
-            position: relative;
-        }
-        
-        .preview-close {
-            position: absolute;
-            top: 1rem;
-            right: 1rem;
-            background: #dc3545;
-            color: white;
+
+        .pb-inspector__footer button {
+            background: var(--pb-accent);
+            color: #fff;
             border: none;
-            border-radius: 50%;
-            width: 30px;
-            height: 30px;
+            padding: 0.7rem 1rem;
+            border-radius: 10px;
             cursor: pointer;
-            font-size: 1rem;
-        }
-        
-        /* Stili per campi array dinamici */
-        .array-field {
-            border: 1px solid #dee2e6;
-            border-radius: 6px;
-            padding: 1rem;
-            margin-bottom: 1rem;
-            background: #f8f9fa;
-        }
-        
-        .array-header {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            margin-bottom: 1rem;
             font-weight: 600;
-            color: #2c3e50;
         }
-        
-        .btn-add {
-            background: #28a745;
-            color: white;
-            padding: 0.25rem 0.5rem;
-            font-size: 0.8rem;
+
+        .pb-inspector__footer button.secondary {
+            background: rgba(255, 255, 255, 0.08);
+            border: 1px solid var(--pb-border);
+            color: var(--pb-text);
         }
-        
-        .array-item {
-            background: white;
-            border: 1px solid #dee2e6;
-            border-radius: 4px;
-            margin-bottom: 0.5rem;
-            overflow: hidden;
-        }
-        
-        .array-item-header {
-            background: #e9ecef;
-            padding: 0.5rem 1rem;
+
+        .pb-toast {
+            position: fixed;
+            top: 1.5rem;
+            right: 1.5rem;
+            background: rgba(18, 23, 32, 0.92);
+            border: 1px solid rgba(35, 168, 235, 0.45);
+            color: #fff;
+            padding: 0.85rem 1.1rem;
+            border-radius: 12px;
             display: flex;
-            justify-content: space-between;
+            gap: 0.65rem;
             align-items: center;
-            font-weight: 500;
-            color: #495057;
+            box-shadow: 0 18px 32px rgba(0, 0, 0, 0.35);
+            z-index: 2000;
         }
-        
-        .array-item-fields {
-            padding: 1rem;
+
+        .pb-toast.pb-toast--error {
+            border-color: rgba(255, 86, 120, 0.7);
         }
-        
-        .checkbox-label {
-            display: flex;
-            align-items: center;
-            gap: 0.5rem;
-            font-weight: normal;
-            margin-bottom: 0;
+
+        .pb-toast.pb-toast--success {
+            border-color: rgba(46, 204, 113, 0.65);
         }
-        
-        .checkbox-label input[type="checkbox"] {
-            width: auto;
-            margin: 0;
+
+        .pb-status-dot {
+            display: inline-block;
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            margin-right: 0.3rem;
+        }
+
+        .pb-status-dot.success { background: var(--pb-success); }
+        .pb-status-dot.warning { background: var(--pb-warning); }
+        .pb-status-dot.danger { background: var(--pb-danger); }
+
+        @media (max-width: 1360px) {
+            .pb-main {
+                grid-template-columns: var(--pb-sidebar-width) 1fr;
+                grid-template-rows: auto auto;
+            }
+            .pb-inspector {
+                grid-column: 1 / -1;
+                flex-direction: column;
+            }
         }
     </style>
 </head>
 <body>
-    <div class="page-builder">
-        <!-- Sidebar Sinistra - Pagine e Moduli -->
-        <div class="sidebar">
-            <h3><i class="fas fa-edit"></i> Page Builder</h3>
-            <?php if ($currentPage): ?>
-                <p><strong><?= htmlspecialchars($currentPage['title']) ?></strong></p>
-                <p>ID: <?= $currentPage['id'] ?></p>
-            <?php endif; ?>
-            
-            <div class="page-selector">
-                <select id="page-selector" onchange="loadPage(this.value)">
-                    <?php foreach ($pages as $page): ?>
-                        <option value="<?= $page['id'] ?>" <?= $page['id'] == $pageId ? 'selected' : '' ?>>
-                            <?= htmlspecialchars($page['title']) ?>
-                        </option>
-                    <?php endforeach; ?>
-                </select>
+    <div class="pb-shell">
+        <header class="pb-header">
+            <div class="pb-header__titles">
+                <h1><i class="fa-solid fa-object-group"></i> Builder visivo</h1>
+                <p>Organizza moduli con drag & drop, modifica inline e gestisci le pagine del sito</p>
             </div>
-            
-            <div style="margin: 1rem 0;">
-                <button class="btn-small btn-preview" onclick="previewPage()" style="width: 100%; margin-bottom: 0.5rem;">
-                    <i class="fas fa-eye"></i> Anteprima
-                </button>
-                <a href="../index.php?id_pagina=<?= $pageId ?>" target="_blank" class="btn-small btn-preview" style="width: 100%; display: block; text-align: center; margin-bottom: 0.5rem;">
-                    <i class="fas fa-external-link-alt"></i> Vedi Pagina
-                </a>
+            <div class="pb-header__actions">
+                <div class="pb-page-switcher">
+                    <select id="pb-page-selector"></select>
+                    <button id="pb-create-page" title="Nuova pagina"><i class="fa-solid fa-plus"></i></button>
+                    <button id="pb-rename-page" title="Rinomina pagina"><i class="fa-solid fa-pen"></i></button>
+                    <button id="pb-delete-page" title="Elimina pagina"><i class="fa-solid fa-trash"></i></button>
+                </div>
+                <div class="pb-badges" id="pb-change-badges"></div>
             </div>
-            
-            <h3><i class="fas fa-puzzle-piece"></i> Moduli Disponibili</h3>
-            <div class="module-list">
-                <?php foreach ($availableModules as $module): ?>
-                    <div class="module-item" data-module="<?= htmlspecialchars($module['name']) ?>" 
-                         onclick="addModule('<?= htmlspecialchars($module['name']) ?>')">
-                        <span>
-                            <i class="fas fa-cube"></i>
-                            <?= htmlspecialchars($module['name']) ?>
-                        </span>
-                        <i class="fas fa-plus"></i>
+        </header>
+
+        <main class="pb-main">
+            <aside class="pb-sidebar">
+                <div class="pb-sidebar__header">
+                    <strong>Libreria moduli</strong>
+                    <span id="pb-module-count"></span>
+                </div>
+                <div class="pb-module-search">
+                    <i class="fa-solid fa-magnifying-glass"></i>
+                    <input type="search" id="pb-module-search" placeholder="Cerca modulo per nome, tag o categoria">
+                </div>
+                <div class="pb-modules__list" id="pb-modules"></div>
+            </aside>
+
+            <section class="pb-stage-panel">
+                <div class="pb-stage-toolbar">
+                    <div class="pb-stage-toolbar__info">
+                        <strong id="pb-current-page-name"></strong>
+                        <span id="pb-current-page-slug" style="display:block;font-size:0.85rem;color:rgba(255,255,255,0.5);"></span>
                     </div>
-                <?php endforeach; ?>
-            </div>
-        </div>
-        
-        <!-- Contenuto Principale -->
-        <div class="main-content">
-            <div class="page-canvas" id="page-canvas">
-                <?php if (empty($moduleInstances)): ?>
-                    <div class="empty-state">
-                        <i class="fas fa-plus-circle"></i>
-                        <h3>Nessun modulo aggiunto</h3>
-                        <p>Trascina i moduli dalla barra laterale per iniziare a costruire la pagina</p>
+                    <div class="pb-stage-toolbar__actions">
+                        <button id="pb-inline-toggle"><i class="fa-solid fa-i-cursor"></i> Inline edit</button>
+                        <button id="pb-preview-page"><i class="fa-solid fa-eye"></i> Anteprima</button>
                     </div>
-                <?php else: ?>
-                    <?php foreach ($moduleInstances as $instance): ?>
-                        <div class="module-instance" data-instance-id="<?= $instance['id'] ?>" 
-                             data-module-name="<?= htmlspecialchars($instance['module_name']) ?>"
-                             data-instance-name="<?= htmlspecialchars($instance['instance_name']) ?>">
-                            <div class="module-header">
-                                <div>
-                                    <i class="fas fa-cube"></i>
-                                    <?= htmlspecialchars($instance['module_name']) ?> - <?= htmlspecialchars($instance['instance_name']) ?>
-                                </div>
-                                <div class="module-controls">
-                                    <button class="btn-small btn-preview" data-action="preview" data-instance-id="<?= $instance['id'] ?>">
-                                        <i class="fas fa-eye"></i>
-                                    </button>
-                                    <button class="btn-small btn-edit" data-action="edit" data-instance-id="<?= $instance['id'] ?>">
-                                        <i class="fas fa-edit"></i>
-                                    </button>
-                                    <button class="btn-small btn-delete" data-action="delete" data-instance-id="<?= $instance['id'] ?>">
-                                        <i class="fas fa-trash"></i>
-                                    </button>
-                                </div>
-                            </div>
-                            <div class="module-content">
-                                <?php
-                                try {
-                                    $config = json_decode($instance['config'], true) ?? [];
-                                    echo $renderer->renderModule($instance['module_name'], $config);
-                                } catch (Exception $e) {
-                                    echo '<div style="color: #dc3545; padding: 1rem;">Errore rendering: ' . htmlspecialchars($e->getMessage()) . '</div>';
-                                }
-                                ?>
-                            </div>
-                        </div>
-                    <?php endforeach; ?>
-                <?php endif; ?>
-            </div>
-        </div>
-        
-        <!-- Sidebar Destra - Configurazione -->
-        <div class="config-panel" id="config-panel">
-            <h3><i class="fas fa-cog"></i> Configurazione</h3>
-            <div id="config-content">
-                <p>Seleziona un modulo per configurarlo</p>
-            </div>
-        </div>
+                </div>
+                <div class="pb-stage pb-drop-target" id="pb-stage" data-parent="root"></div>
+            </section>
+
+            <aside class="pb-inspector">
+                <div class="pb-inspector__header">
+                    <strong>Inspector</strong>
+                    <span id="pb-selected-label" style="font-size:0.85rem;color:rgba(255,255,255,0.5);"></span>
+                </div>
+                <div class="pb-inspector__body" id="pb-inspector-body">
+                    <p>Seleziona un modulo sullo stage per modificarne le proprietà oppure attiva l'inline editing.</p>
+                </div>
+                <div class="pb-inspector__footer">
+                    <button id="pb-save-config" style="display:none;"><i class="fa-solid fa-floppy-disk"></i> Salva configurazione</button>
+                    <button id="pb-cancel-inline" class="secondary" style="display:none;">Annulla modifiche inline</button>
+                </div>
+            </aside>
+        </main>
     </div>
-    
-    <!-- Modal Anteprima -->
-    <div class="preview-modal" id="preview-modal">
-        <div class="preview-content">
-            <button class="preview-close" onclick="closePreview()">&times;</button>
-            <div id="preview-body"></div>
-        </div>
-    </div>
-    
-    <!-- JavaScript -->
+
+    <div id="pb-toast" class="pb-toast" style="display:none;"></div>
+
     <script src="../node_modules/sortablejs/Sortable.min.js"></script>
     <script>
-        let currentPageId = <?= $pageId ?>;
-        let selectedInstance = null;
-        let instanceCounter = {};
-        
-        // Utility per debounce
-        function debounce(func, wait) {
-            let timeout;
-            return function executedFunction(...args) {
-                const later = () => {
-                    clearTimeout(timeout);
-                    func(...args);
-                };
-                clearTimeout(timeout);
-                timeout = setTimeout(later, wait);
-            };
-        }
-        
-        // Inizializza drag & drop
-        const canvas = document.getElementById('page-canvas');
-        const sortable = Sortable.create(canvas, {
-            animation: 150,
-            ghostClass: 'drag-placeholder',
-            onEnd: function(evt) {
-                updateOrder();
-            }
-        });
-        
-        // Inizializza contatori moduli
-        function initializeModuleCounters() {
-            const instances = document.querySelectorAll('.module-instance');
-            instanceCounter = {};
-            
-            console.log('Inizializzazione contatori per', instances.length, 'moduli');
-            
-            instances.forEach((instance, index) => {
-                const moduleName = instance.getAttribute('data-module-name');
-                const instanceName = instance.getAttribute('data-instance-name');
-                const instanceId = instance.getAttribute('data-instance-id');
-                
-                console.log(`Modulo ${index + 1}: ${moduleName} - ${instanceName} (ID: ${instanceId})`);
-                
-                if (moduleName && instanceName) {
-                    if (!instanceCounter[moduleName]) {
-                        instanceCounter[moduleName] = 0;
-                    }
-                    
-                    // Estrai numero dal nome istanza (es. button_2 -> 2)
-                    const match = instanceName.match(/_(\d+)$/);
-                    if (match) {
-                        const num = parseInt(match[1]);
-                        if (num > instanceCounter[moduleName]) {
-                            instanceCounter[moduleName] = num;
-                        }
-                    }
-                }
-            });
-            
-            console.log('Contatori moduli aggiornati:', instanceCounter);
-        }
-        
-        // Inizializza contatori al caricamento
-        initializeModuleCounters();
-        
-        // Funzione per pulire moduli fantasma (moduli con attributi mancanti)
-        function cleanupGhostModules() {
-            const instances = document.querySelectorAll('.module-instance');
-            let cleanedCount = 0;
-            
-            instances.forEach(instance => {
-                const moduleName = instance.getAttribute('data-module-name');
-                const instanceName = instance.getAttribute('data-instance-name');
-                const instanceId = instance.getAttribute('data-instance-id');
-                
-                // Se mancano attributi essenziali, rimuovi il modulo
-                if (!moduleName || !instanceName || !instanceId) {
-                    console.warn('Rimosso modulo fantasma:', instance);
-                    instance.remove();
-                    cleanedCount++;
-                }
-            });
-            
-            if (cleanedCount > 0) {
-                console.log(`Puliti ${cleanedCount} moduli fantasma`);
-                // Reinizializza contatori dopo la pulizia
-                initializeModuleCounters();
-            }
-        }
-        
-        // Pulisci moduli fantasma al caricamento
-        setTimeout(cleanupGhostModules, 500);
-        
-        // Funzione per forzare il refresh dei contatori
-        function forceRefreshCounters() {
-            console.log('Forzando refresh contatori...');
-            cleanupGhostModules();
-            initializeModuleCounters();
-            console.log('Refresh contatori completato');
-        }
-        
-        // Aggiungi funzione globale per debug
-        window.refreshCounters = forceRefreshCounters;
-        
-        // Riattacca event listener a tutti i moduli
-        function reattachModuleListeners() {
-            const moduleInstances = document.querySelectorAll('.module-instance');
-            console.log(`Riattaccando event listener a ${moduleInstances.length} moduli`);
-            
-            moduleInstances.forEach((instance, index) => {
-                // Rimuovi eventuali listener esistenti
-                instance.removeEventListener('click', handleModuleClick);
-                
-                // Aggiungi nuovo listener per il modulo
-                instance.addEventListener('click', handleModuleClick);
-                
-                // Gestisci i pulsanti di controllo
-                const controlButtons = instance.querySelectorAll('.module-controls button');
-                controlButtons.forEach(button => {
-                    // Rimuovi eventuali listener esistenti
-                    button.removeEventListener('click', handleControlButtonClick);
-                    
-                    // Aggiungi nuovo listener
-                    button.addEventListener('click', handleControlButtonClick);
-                });
-                
-                // Debug: verifica che l'event listener sia attivo
-                const moduleName = instance.getAttribute('data-module-name');
-                const instanceName = instance.getAttribute('data-instance-name');
-                const instanceId = instance.getAttribute('data-instance-id');
-                console.log(`Event listener riattaccato al modulo ${index + 1}: ${moduleName} (${instanceName}) [ID: ${instanceId}]`);
-            });
-        }
-        
-        // Gestisce il click sui moduli
-        function handleModuleClick(event) {
-            event.stopPropagation();
-            console.log('Click rilevato su modulo:', this.getAttribute('data-module-name'));
-            selectInstance(this);
-        }
-        
-        // Gestisce il click sui pulsanti di controllo
-        function handleControlButtonClick(event) {
-            event.stopPropagation();
-            
-            const action = this.getAttribute('data-action');
-            const instanceId = this.getAttribute('data-instance-id');
-            
-            console.log(`Click su pulsante ${action} per istanza ${instanceId}`);
-            
-            // Trova il modulo padre
-            const moduleInstance = this.closest('.module-instance');
-            if (!moduleInstance) {
-                console.error('Modulo padre non trovato');
-                return;
-            }
-            
-            console.log('Modulo padre trovato:', moduleInstance.getAttribute('data-module-name'), moduleInstance.getAttribute('data-instance-name'));
-            
-            switch(action) {
-                case 'preview':
-                    previewInstance(instanceId);
-                    break;
-                case 'edit':
-                    selectInstance(moduleInstance);
-                    break;
-                case 'delete':
-                    // Per moduli temporanei, assicurati che selectedInstance sia corretto
-                    if (instanceId === 'temp') {
-                        selectedInstance = moduleInstance;
-                        console.log('Impostato selectedInstance per eliminazione modulo temporaneo');
-                    }
-                    deleteInstance(instanceId);
-                    break;
-                default:
-                    console.error('Azione sconosciuta:', action);
-            }
-        }
-        
-        // Inizializza event listener al caricamento
-        reattachModuleListeners();
-        
-        // Riattacca event listener quando il DOM è pronto
-        document.addEventListener('DOMContentLoaded', function() {
-            reattachModuleListeners();
-        });
-        
-        // Riattacca event listener anche quando la finestra è ridimensionata (per sicurezza)
-        window.addEventListener('resize', function() {
-            setTimeout(reattachModuleListeners, 100);
-        });
-        
-        // Carica pagina
-        function loadPage(pageId) {
-            window.location.href = `?page_id=${pageId}`;
-        }
-        
-        // Aggiungi modulo
-        function addModule(moduleName) {
-            if (!currentPageId) {
-                alert('Seleziona prima una pagina');
-                return;
-            }
-            
-            // Verifica se esiste già un modulo temporaneo dello stesso tipo
-            const existingTempModule = document.querySelector(`[data-module-name="${moduleName}"][data-instance-id="temp"]`);
-            if (existingTempModule) {
-                alert('Esiste già un modulo temporaneo di questo tipo. Configuralo prima di aggiungerne un altro.');
-                existingTempModule.scrollIntoView({ behavior: 'smooth' });
-                selectInstance(existingTempModule);
-                return;
-            }
-            
-            // Genera nome istanza unico basato sui moduli esistenti
-            const existingInstances = document.querySelectorAll(`[data-module-name="${moduleName}"]`);
-            let counter = 1;
-            let instanceName = `${moduleName}_${counter}`;
-            
-            // Verifica che il nome sia davvero unico
-            while (document.querySelector(`[data-instance-name="${instanceName}"]`)) {
-                counter++;
-                instanceName = `${moduleName}_${counter}`;
-            }
-            
-            console.log(`Generato nome istanza: ${instanceName} per modulo ${moduleName} (contatore: ${counter})`);
-            console.log(`Moduli esistenti di tipo ${moduleName}:`, existingInstances.length);
-            
-            // Debug: mostra tutti i moduli esistenti di questo tipo
-            existingInstances.forEach((instance, index) => {
-                console.log(`  Modulo ${index + 1}: ${instance.getAttribute('data-instance-name')} (ID: ${instance.getAttribute('data-instance-id')})`);
-            });
-            
-            const orderIndex = document.querySelectorAll('.module-instance').length;
-            
-            // Crea elemento temporaneo
-            const tempDiv = document.createElement('div');
-            tempDiv.className = 'module-instance';
-            tempDiv.setAttribute('data-instance-id', 'temp');
-            tempDiv.setAttribute('data-module-name', moduleName);
-            tempDiv.setAttribute('data-instance-name', instanceName);
-            tempDiv.innerHTML = `
-                <div class="module-header">
-                    <div><i class="fas fa-cube"></i> ${moduleName} - ${instanceName}</div>
-                    <div class="module-controls">
-                        <button class="btn-small btn-edit" data-action="edit" data-instance-id="temp">
-                            <i class="fas fa-edit"></i>
-                        </button>
-                        <button class="btn-small btn-delete" data-action="delete" data-instance-id="temp">
-                            <i class="fas fa-trash"></i>
-                        </button>
-                    </div>
-                </div>
-                <div class="module-content">
-                    <div style="padding: 1rem; color: #6c757d;">
-                        <i class="fas fa-cog"></i> Configura il modulo per vedere l'anteprima
-                    </div>
-                </div>
-            `;
-            
-            // Rimuovi empty state se presente
-            const emptyState = canvas.querySelector('.empty-state');
-            if (emptyState) {
-                emptyState.remove();
-            }
-            
-            canvas.appendChild(tempDiv);
-            
-            // Seleziona prima il modulo
-            selectInstance(tempDiv);
-            
-            // Riattacca event listener dopo aver aggiunto il nuovo modulo
-            setTimeout(() => {
-                reattachModuleListeners();
-            }, 100);
-            
-            // NON salvare automaticamente i moduli temporanei nel database
-            // Il salvataggio avverrà solo da "Salva Configurazione"
-            // Manteniamo l'istanza come bozza nel DOM (data-instance-id = "temp")
-        }
-        
-        // Seleziona istanza
-        function selectInstance(element) {
-            console.log('Selezionando istanza:', element.getAttribute('data-module-name'), element.getAttribute('data-instance-name'));
-            
-            // Rimuovi selezione precedente
-            document.querySelectorAll('.module-instance').forEach(el => {
-                el.classList.remove('selected-instance');
-            });
-            
-            // Seleziona nuova
-            element.classList.add('selected-instance');
-            selectedInstance = element;
-            
-            console.log('Istanza selezionata con successo');
-            
-            // Carica configurazione
-            loadInstanceConfig(element);
-        }
-        
-        // Carica configurazione istanza
-        function loadInstanceConfig(element) {
-            const moduleName = element.getAttribute('data-module-name');
-            const instanceId = element.getAttribute('data-instance-id');
-            const instanceName = element.getAttribute('data-instance-name');
-            
-            const configPanel = document.getElementById('config-content');
-            
-            // Mostra loading
-            configPanel.innerHTML = '<div style="text-align: center; padding: 2rem;"><i class="fas fa-spinner fa-spin"></i> Caricamento configurazione...</div>';
-            
-            // Carica configurazione dal server
-            const formData = new FormData();
-            formData.append('action', 'get-module-config');
-            formData.append('module_name', moduleName);
-            if (instanceId && instanceId !== 'temp') {
-                formData.append('instance_id', instanceId);
-            }
-            
-            fetch('api/page_builder.php', {
-                method: 'POST',
-                body: formData
-            })
-            .then(response => {
-                if (!response.ok) {
-                    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-                }
-                return response.text().then(text => {
-                    try {
-                        return JSON.parse(text);
-                    } catch (e) {
-                        console.error('JSON Parse Error:', text);
-                        throw new Error('Risposta non valida dal server');
-                    }
-                });
-            })
-            .then(data => {
-                if (data.success) {
-                    renderModuleConfig(moduleName, instanceName, instanceId, data.config, data.manifest);
-                } else {
-                    configPanel.innerHTML = '<div style="color: #dc3545; padding: 1rem;">Errore: ' + (data.error || 'Errore sconosciuto') + '</div>';
-                }
-            })
-            .catch(error => {
-                console.error('Error:', error);
-                configPanel.innerHTML = '<div style="color: #dc3545; padding: 1rem;">Errore durante il caricamento: ' + error.message + '</div>';
-            });
-        }
-        
-        // Renderizza configurazione modulo dinamica basata sul manifest
-        function renderModuleConfig(moduleName, instanceName, instanceId, config, manifest) {
-            const configPanel = document.getElementById('config-content');
-            
-            let html = `
-                <div class="form-group">
-                    <label>Nome Istanza</label>
-                    <input type="text" id="instance-name" value="${instanceName}">
-                </div>
-            `;
-            
-            // Genera campi dinamicamente dal manifest
-            if (manifest.ui_schema) {
-                html += generateDynamicFields(manifest.ui_schema, config);
-            } else {
-                // Modulo senza ui_schema - usa configurazione generica
-                html += `
-                    <div class="form-group">
-                        <label>Titolo</label>
-                        <input type="text" id="config-title" value="${config.title || ''}" placeholder="Titolo del modulo">
-                    </div>
-                    <div class="form-group">
-                        <label>Contenuto</label>
-                        <textarea id="config-content" placeholder="Contenuto del modulo">${config.content || ''}</textarea>
-                    </div>
-                `;
-            }
-            
-            html += `
-                <button class="btn-small btn-edit" onclick="saveInstanceConfig()" style="width: 100%; margin-top: 1rem;">
-                    <i class="fas fa-save"></i> Salva Configurazione
-                </button>
-            `;
-            
-            configPanel.innerHTML = html;
-            
-            // Aggiungi event listeners per aggiornamento in tempo reale
-            setTimeout(() => {
-                const inputs = configPanel.querySelectorAll('input, select, textarea');
-                inputs.forEach(input => {
-                    // Controllo speciale per il nome istanza
-                    if (input.id === 'instance-name') {
-                        input.addEventListener('input', debounce(() => {
-                            validateInstanceName(input.value);
-                        }, 300));
-                    }
-                    
-                    input.addEventListener('input', debounce(() => {
-                        try {
-                            updateModulePreview();
-                        } catch (e) {
-                            console.warn('Preview update skipped:', e.message);
-                        }
-                    }, 500));
-                    input.addEventListener('change', () => {
-                        try {
-                            updateModulePreview();
-                        } catch (e) {
-                            console.warn('Preview update skipped:', e.message);
-                        }
-                    });
-                });
-            }, 100);
-        }
-        
-        // Genera campi dinamicamente dal manifest
-        function generateDynamicFields(uiSchema, config) {
-            let html = '';
-            
-            for (const [fieldName, fieldConfig] of Object.entries(uiSchema)) {
-                const value = config[fieldName] || fieldConfig.default || '';
-                
-                html += `<div class="form-group" data-field="${fieldName}">`;
-                html += `<label>${fieldConfig.label}${fieldConfig.required ? ' *' : ''}</label>`;
-                
-                switch (fieldConfig.type) {
-                    case 'text':
-                        html += `<input type="text" id="config-${fieldName}" value="${value}" placeholder="${fieldConfig.placeholder || ''}">`;
-                        break;
-                        
-                    case 'textarea':
-                        html += `<textarea id="config-${fieldName}" placeholder="${fieldConfig.placeholder || ''}">${value}</textarea>`;
-                        break;
-                        
-                    case 'select':
-                        html += `<select id="config-${fieldName}">`;
-                        for (const option of fieldConfig.options) {
-                            const selected = value === option.value ? 'selected' : '';
-                            html += `<option value="${option.value}" ${selected}>${option.label}</option>`;
-                        }
-                        html += '</select>';
-                        break;
-                        
-                    case 'boolean':
-                        const checked = value ? 'checked' : '';
-                        html += `<label class="checkbox-label"><input type="checkbox" id="config-${fieldName}" ${checked}> ${fieldConfig.label}</label>`;
-                        break;
-                        
-                    case 'color':
-                        html += `<input type="color" id="config-${fieldName}" value="${value}">`;
-                        break;
-                        
-                    case 'image':
-                        html += `<input type="url" id="config-${fieldName}" value="${value}" placeholder="${fieldConfig.placeholder || 'URL dell\'immagine'}">`;
-                        break;
-                        
-                    case 'array':
-                        html += generateArrayField(fieldName, fieldConfig, value);
-                        break;
-                        
-                    default:
-                        html += `<input type="text" id="config-${fieldName}" value="${value}" placeholder="${fieldConfig.placeholder || ''}">`;
-                }
-                
-                html += '</div>';
-            }
-            
-            return html;
-        }
-        
-        // Genera campo array (es. voci menu)
-        function generateArrayField(fieldName, fieldConfig, value) {
-            const items = Array.isArray(value) ? value : [];
-            
-            let html = `
-                <div class="array-field" id="config-${fieldName}-container">
-                    <div class="array-header">
-                        <span>${fieldConfig.label}</span>
-                        <button type="button" class="btn-small btn-add" onclick="addArrayItem('${fieldName}')">
-                            <i class="fas fa-plus"></i> Aggiungi
-                        </button>
-                    </div>
-                    <div class="array-items" id="config-${fieldName}-items">
-            `;
-            
-            items.forEach((item, index) => {
-                html += generateArrayItem(fieldName, fieldConfig.item_schema, item, index);
-            });
-            
-            html += `
-                    </div>
-                </div>
-            `;
-            
-            return html;
-        }
-        
-        // Genera singolo item dell'array
-        function generateArrayItem(fieldName, itemSchema, item, index) {
-            let html = `
-                <div class="array-item" data-index="${index}">
-                    <div class="array-item-header">
-                        <span>Elemento ${index + 1}</span>
-                        <button type="button" class="btn-small btn-delete" onclick="removeArrayItem('${fieldName}', ${index})">
-                            <i class="fas fa-trash"></i>
-                        </button>
-                    </div>
-                    <div class="array-item-fields">
-            `;
-            
-            for (const [subFieldName, subFieldConfig] of Object.entries(itemSchema)) {
-                const subValue = item[subFieldName] || '';
-                const subFieldId = `config-${fieldName}-${index}-${subFieldName}`;
-                
-                html += `<div class="form-group">`;
-                html += `<label>${subFieldConfig.label}</label>`;
-                
-                switch (subFieldConfig.type) {
-                    case 'text':
-                        html += `<input type="text" id="${subFieldId}" value="${subValue}" placeholder="${subFieldConfig.placeholder || ''}">`;
-                        break;
-                    case 'url':
-                        html += `<input type="url" id="${subFieldId}" value="${subValue}" placeholder="${subFieldConfig.placeholder || ''}">`;
-                        break;
-                    case 'select':
-                        html += `<select id="${subFieldId}">`;
-                        for (const option of subFieldConfig.options) {
-                            const selected = subValue === option.value ? 'selected' : '';
-                            html += `<option value="${option.value}" ${selected}>${option.label}</option>`;
-                        }
-                        html += '</select>';
-                        break;
-                    default:
-                        html += `<input type="text" id="${subFieldId}" value="${subValue}">`;
-                }
-                
-                html += '</div>';
-            }
-            
-            html += `
-                    </div>
-                </div>
-            `;
-            
-            return html;
-        }
-        
-        // Aggiungi item all'array
-        function addArrayItem(fieldName) {
-            const container = document.getElementById(`config-${fieldName}-items`);
-            const itemSchema = getItemSchema(fieldName);
-            const newIndex = container.children.length;
-            
-            const newItem = generateArrayItem(fieldName, itemSchema, {}, newIndex);
-            container.insertAdjacentHTML('beforeend', newItem);
-            
-            // Riattacca event listeners
-            reattachModuleListeners();
-        }
-        
-        // Rimuovi item dall'array
-        function removeArrayItem(fieldName, index) {
-            const container = document.getElementById(`config-${fieldName}-items`);
-            const item = container.querySelector(`[data-index="${index}"]`);
-            if (item) {
-                item.remove();
-                
-                // Rinumera gli indici
-                container.querySelectorAll('.array-item').forEach((el, newIndex) => {
-                    el.setAttribute('data-index', newIndex);
-                    el.querySelector('.array-item-header span').textContent = `Elemento ${newIndex + 1}`;
-                });
-            }
-        }
-        
-        // Ottieni schema dell'item (da implementare)
-        function getItemSchema(fieldName) {
-            // Per ora hardcoded per menu_items, poi si può migliorare
-            return {
-                label: { type: 'text', label: 'Etichetta', required: true },
-                url: { type: 'url', label: 'URL', required: true },
-                target: { 
-                    type: 'select', 
-                    label: 'Target',
-                    options: [
-                        { value: '_self', label: 'Stessa Finestra' },
-                        { value: '_blank', label: 'Nuova Finestra' }
-                    ]
-                }
-            };
-        }
-        
-        // Salva configurazione istanza
-        function saveInstanceConfig() {
-            if (!selectedInstance) return;
-            
-            const moduleName = selectedInstance.getAttribute('data-module-name');
-            const instanceId = selectedInstance.getAttribute('data-instance-id');
-            const instanceNameEl = document.getElementById('instance-name');
-            
-            if (!instanceNameEl) {
-                alert('Errore: campo nome istanza non trovato');
-                return;
-            }
-            
-            const instanceName = instanceNameEl.value.trim();
-            if (!instanceName) {
-                alert('Il nome dell\'istanza non può essere vuoto');
-                return;
-            }
-            
-            // Verifica duplicazione lato client
-            const currentInstanceId = selectedInstance.getAttribute('data-instance-id');
-            const existingInstances = document.querySelectorAll('.module-instance');
-            let duplicateFound = false;
-            
-            for (let instance of existingInstances) {
-                const otherInstanceId = instance.getAttribute('data-instance-id');
-                const otherInstanceName = instance.getAttribute('data-instance-name');
-                
-                // Salta l'istanza corrente
-                if (otherInstanceId === currentInstanceId) continue;
-                
-                // Se troviamo un'altra istanza con lo stesso nome, blocca
-                if (otherInstanceName === instanceName) {
-                    duplicateFound = true;
-                    break;
-                }
-            }
-            
-            if (duplicateFound) {
-                alert('Esiste già un\'istanza con questo nome sulla stessa pagina. Scegli un nome diverso.');
-                return;
-            }
-            
-            console.log(`Nome istanza validato: ${instanceName} per istanza ${currentInstanceId}`);
-            
-            // Raccogli configurazione dinamicamente
-            let config = {};
-            
-            try {
-                // Raccogli configurazione dinamicamente
-                config = collectDynamicConfig();
-                
-                // Salva nel database
-                saveInstance(moduleName, instanceName, config, null, instanceId);
-                
-            } catch (error) {
-                console.error('Errore durante il salvataggio:', error);
-                alert('Errore durante il salvataggio: ' + error.message);
-            }
-        }
-        
-        // Raccogli configurazione dinamicamente dai campi
-        function collectDynamicConfig() {
-            const config = {};
-            const formGroups = document.querySelectorAll('.form-group[data-field]');
-            
-            formGroups.forEach(group => {
-                const fieldName = group.getAttribute('data-field');
-                const input = group.querySelector('input, select, textarea');
-                
-                if (input) {
-                    if (input.type === 'checkbox') {
-                        config[fieldName] = input.checked;
-                    } else {
-                        config[fieldName] = input.value;
-                    }
-                }
-            });
-            
-            // Gestisci campi array (es. menu_items)
-            const arrayFields = document.querySelectorAll('.array-field');
-            arrayFields.forEach(arrayField => {
-                const fieldName = arrayField.id.replace('config-', '').replace('-container', '');
-                const items = [];
-                
-                arrayField.querySelectorAll('.array-item').forEach((item, index) => {
-                    const itemData = {};
-                    item.querySelectorAll('.form-group input, .form-group select').forEach(input => {
-                        const subFieldName = input.id.split('-').pop();
-                        itemData[subFieldName] = input.value;
-                    });
-                    items.push(itemData);
-                });
-                
-                config[fieldName] = items;
-            });
-            
-            return config;
-        }
-        
-        // Salva istanza nel database
-        function saveInstance(moduleName, instanceName, config, orderIndex, instanceId) {
-            const formData = new FormData();
-            formData.append('action', 'save-instance');
-            formData.append('page_id', currentPageId);
-            formData.append('module_name', moduleName);
-            formData.append('instance_name', instanceName);
-            formData.append('config', JSON.stringify(config));
-            if (orderIndex !== null) {
-                formData.append('order_index', orderIndex);
-            }
-            
-            // Passa l'ID dell'istanza corrente se disponibile
-            if (instanceId && instanceId !== 'temp') {
-                formData.append('current_instance_id', instanceId);
-            }
-            
-            // Mostra loading
-            const saveButton = document.querySelector('button[onclick="saveInstanceConfig()"]');
-            if (saveButton) {
-                saveButton.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Salvataggio...';
-                saveButton.disabled = true;
-            }
-            
-            fetch('api/page_builder.php', {
-                method: 'POST',
-                body: formData
-            })
-            .then(response => {
-                if (!response.ok) {
-                    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-                }
-                return response.text().then(text => {
-                    try {
-                        return JSON.parse(text);
-                    } catch (e) {
-                        console.error('JSON Parse Error:', text);
-                        throw new Error('Risposta non valida dal server');
-                    }
-                });
-            })
-            .then(data => {
-                if (data.success) {
-                    if (instanceId === 'temp') {
-                        selectedInstance.setAttribute('data-instance-id', data.id);
-                        // Aggiorna il titolo dell'header
-                        const headerTitle = selectedInstance.querySelector('.module-header div');
-                        if (headerTitle) {
-                            headerTitle.innerHTML = `<i class="fas fa-cube"></i> ${moduleName} - ${instanceName}`;
-                        }
-                        // Aggiorna i data-attribute dei pulsanti di controllo con il nuovo ID
-                        const controlButtons = selectedInstance.querySelectorAll('.module-controls button');
-                        controlButtons.forEach(btn => {
-                            btn.setAttribute('data-instance-id', data.id);
-                        });
-                    }
-                    
-                    // Aggiorna preview
-                    updateModulePreview();
-                    
-                    // Riattacca event listener dopo il salvataggio
-                    setTimeout(() => {
-                        reattachModuleListeners();
-                    }, 100);
-                    
-                    // Mostra messaggio di successo
-                    const configPanel = document.getElementById('config-content');
-                    const successMsg = document.createElement('div');
-                    successMsg.style.cssText = 'background: #d4edda; color: #155724; padding: 0.5rem; border-radius: 4px; margin-bottom: 1rem; font-size: 0.9rem;';
-                    successMsg.innerHTML = '<i class="fas fa-check"></i> Configurazione salvata con successo!';
-                    configPanel.insertBefore(successMsg, configPanel.firstChild);
-                    
-                    // Rimuovi messaggio dopo 3 secondi
-                    setTimeout(() => {
-                        if (successMsg.parentNode) {
-                            successMsg.remove();
-                        }
-                    }, 3000);
-                    
-                } else {
-                    const errorMsg = data.error || 'Errore sconosciuto';
-                    
-                    // Mostra errore nel pannello di configurazione se è un errore di duplicazione
-                    if (errorMsg.includes('Esiste già un\'istanza')) {
-                        const configPanel = document.getElementById('config-content');
-                        const errorDiv = document.createElement('div');
-                        errorDiv.style.cssText = 'background: #f8d7da; color: #721c24; padding: 0.5rem; border-radius: 4px; margin-bottom: 1rem; font-size: 0.9rem;';
-                        errorDiv.innerHTML = '<i class="fas fa-exclamation-triangle"></i> ' + errorMsg;
-                        configPanel.insertBefore(errorDiv, configPanel.firstChild);
-                        
-                        // Rimuovi messaggio dopo 5 secondi
-                        setTimeout(() => {
-                            if (errorDiv.parentNode) {
-                                errorDiv.remove();
-                            }
-                        }, 5000);
-                    } else {
-                        alert('Errore: ' + errorMsg);
-                    }
-                }
-            })
-            .catch(error => {
-                console.error('Error:', error);
-                alert('Errore durante il salvataggio: ' + error.message);
-            })
-            .finally(() => {
-                // Ripristina pulsante
-                if (saveButton) {
-                    saveButton.innerHTML = '<i class="fas fa-save"></i> Salva Configurazione';
-                    saveButton.disabled = false;
-                }
-            });
-        }
-        
-        // Aggiorna ordine
-        function updateOrder() {
-            const instances = document.querySelectorAll('.module-instance');
-            const updates = [];
-            
-            instances.forEach((instance, index) => {
-                const instanceId = instance.getAttribute('data-instance-id');
-                if (instanceId !== 'temp') {
-                    updates.push({
-                        id: instanceId,
-                        page_id: currentPageId,
-                        order_index: index
-                    });
-                }
-            });
-            
-            if (updates.length === 0) return;
-            
-            const formData = new FormData();
-            formData.append('action', 'update-order');
-            formData.append('updates', JSON.stringify(updates));
-            
-            fetch('api/page_builder.php', {
-                method: 'POST',
-                body: formData
-            })
-            .then(response => response.json())
-            .then(data => {
-                if (!data.success) {
-                    console.error('Errore aggiornamento ordine:', data.error);
-                }
-            });
-        }
-        
-        // Elimina istanza
-        function deleteInstance(instanceId) {
-            if (!confirm('Sei sicuro di voler eliminare questo modulo?')) return;
-            
-            console.log('Tentativo eliminazione istanza:', instanceId);
-            
-            // Per moduli temporanei, usa l'istanza selezionata
-            let instanceElement;
-            if (instanceId === 'temp') {
-                instanceElement = selectedInstance;
-                console.log('Eliminazione modulo temporaneo, uso selectedInstance');
-            } else {
-                instanceElement = document.querySelector(`[data-instance-id="${instanceId}"]`);
-            }
-            
-            if (!instanceElement) {
-                console.error('Elemento modulo non trovato per ID:', instanceId);
-                console.log('Moduli disponibili:');
-                document.querySelectorAll('.module-instance').forEach((el, index) => {
-                    console.log(`${index + 1}: ID=${el.getAttribute('data-instance-id')}, Modulo=${el.getAttribute('data-module-name')}, Nome=${el.getAttribute('data-instance-name')}`);
-                });
-                console.log('selectedInstance:', selectedInstance);
-                return;
-            }
-            
-            console.log('Elemento modulo trovato:', instanceElement.getAttribute('data-module-name'), instanceElement.getAttribute('data-instance-name'));
-            
-            if (instanceId === 'temp') {
-                // Rimuovi elemento temporaneo
-                instanceElement.remove();
-                selectedInstance = null;
-                document.getElementById('config-content').innerHTML = '<p>Seleziona un modulo per configurarlo</p>';
-                
-                // Riattacca event listener dopo l'eliminazione
-                reattachModuleListeners();
-                
-                // Aggiorna contatori dopo l'eliminazione
-                initializeModuleCounters();
-                
-                // Verifica se rimangono altri moduli
-                checkEmptyState();
-                return;
-            }
-            
-            const formData = new FormData();
-            formData.append('action', 'delete-instance');
-            formData.append('instance_id', instanceId);
-            formData.append('page_id', currentPageId);
-            
-            fetch('api/page_builder.php', {
-                method: 'POST',
-                body: formData
-            })
-            .then(response => {
-                if (!response.ok) {
-                    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-                }
-                return response.text().then(text => {
-                    try {
-                        return JSON.parse(text);
-                    } catch (e) {
-                        console.error('JSON Parse Error:', text);
-                        throw new Error('Risposta non valida dal server');
-                    }
-                });
-            })
-            .then(data => {
-                if (data.success) {
-                    instanceElement.remove();
-                    selectedInstance = null;
-                    document.getElementById('config-content').innerHTML = '<p>Seleziona un modulo per configurarlo</p>';
-                    
-                    // Riattacca event listener dopo l'eliminazione
-                    reattachModuleListeners();
-                    
-                    // Aggiorna contatori dopo l'eliminazione
-                    initializeModuleCounters();
-                    
-                    // Verifica se rimangono altri moduli
-                    checkEmptyState();
-                } else {
-                    alert('Errore: ' + (data.error || 'Errore sconosciuto'));
-                }
-            })
-            .catch(error => {
-                console.error('Error:', error);
-                alert('Errore durante l\'eliminazione: ' + error.message);
-            });
-        }
-        
-        // Verifica se la pagina è vuota e mostra empty state
-        function checkEmptyState() {
-            const canvas = document.getElementById('page-canvas');
-            const instances = canvas.querySelectorAll('.module-instance');
-            
-            if (instances.length === 0) {
-                const emptyState = document.createElement('div');
-                emptyState.className = 'empty-state';
-                emptyState.innerHTML = `
-                    <i class="fas fa-plus-circle"></i>
-                    <h3>Nessun modulo aggiunto</h3>
-                    <p>Trascina i moduli dalla barra laterale per iniziare a costruire la pagina</p>
-                `;
-                canvas.appendChild(emptyState);
-            }
-        }
-        
-        // Valida nome istanza in tempo reale
-        function validateInstanceName(instanceName) {
-            if (!instanceName || !instanceName.trim()) {
-                removeValidationMessage();
-                return;
-            }
-            
-            const currentInstanceId = selectedInstance?.getAttribute('data-instance-id');
-            const existingInstances = document.querySelectorAll('.module-instance');
-            let duplicateFound = false;
-            
-            for (let instance of existingInstances) {
-                const otherInstanceId = instance.getAttribute('data-instance-id');
-                const otherInstanceName = instance.getAttribute('data-instance-name');
-                
-                // Salta l'istanza corrente
-                if (otherInstanceId === currentInstanceId) continue;
-                
-                // Se troviamo un'altra istanza con lo stesso nome
-                if (otherInstanceName === instanceName.trim()) {
-                    duplicateFound = true;
-                    break;
-                }
-            }
-            
-            if (duplicateFound) {
-                showValidationMessage('warning', 'Esiste già un\'istanza con questo nome');
-            } else {
-                removeValidationMessage();
-            }
-        }
-        
-        // Mostra messaggio di validazione
-        function showValidationMessage(type, message) {
-            removeValidationMessage();
-            
-            const instanceNameInput = document.getElementById('instance-name');
-            if (!instanceNameInput) return;
-            
-            const validationDiv = document.createElement('div');
-            validationDiv.id = 'instance-name-validation';
-            validationDiv.style.cssText = type === 'warning' 
-                ? 'color: #856404; background: #fff3cd; border: 1px solid #ffeaa7; padding: 0.25rem 0.5rem; border-radius: 4px; font-size: 0.8rem; margin-top: 0.25rem;'
-                : 'color: #155724; background: #d4edda; border: 1px solid #c3e6cb; padding: 0.25rem 0.5rem; border-radius: 4px; font-size: 0.8rem; margin-top: 0.25rem;';
-            
-            validationDiv.innerHTML = `<i class="fas fa-${type === 'warning' ? 'exclamation-triangle' : 'check'}"></i> ${message}`;
-            
-            instanceNameInput.parentNode.insertBefore(validationDiv, instanceNameInput.nextSibling);
-        }
-        
-        // Rimuovi messaggio di validazione
-        function removeValidationMessage() {
-            const existingValidation = document.getElementById('instance-name-validation');
-            if (existingValidation) {
-                existingValidation.remove();
-            }
-        }
-        
-        // Aggiorna preview modulo
-        function updateModulePreview() {
-            if (!selectedInstance) return;
-            
-            const moduleName = selectedInstance.getAttribute('data-module-name');
-            let config = {};
-            
-            // Raccogli configurazione attuale dal form
-            try {
-                // Raccogli configurazione dinamicamente
-                config = collectDynamicConfig();
-            } catch (e) {
-                console.warn('Config non ancora caricata:', e);
-                return;
-            }
-            
-            const formData = new FormData();
-            formData.append('action', 'preview-module');
-            formData.append('module_name', moduleName);
-            formData.append('config', JSON.stringify(config));
-            
-            fetch('api/page_builder.php', {
-                method: 'POST',
-                body: formData
-            })
-            .then(response => {
-                if (!response.ok) {
-                    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-                }
-                return response.text().then(text => {
-                    try {
-                        return JSON.parse(text);
-                    } catch (e) {
-                        console.error('JSON Parse Error:', text);
-                        throw new Error('Risposta non valida dal server');
-                    }
-                });
-            })
-            .then(data => {
-                if (data.success) {
-                    const moduleContent = selectedInstance.querySelector('.module-content');
-                    if (moduleContent) {
-                        moduleContent.innerHTML = data.html;
-                        
-                        // Aggiorna anche il nome dell'istanza se modificato
-                        const instanceNameEl = document.getElementById('instance-name');
-                        if (instanceNameEl) {
-                            selectedInstance.setAttribute('data-instance-name', instanceNameEl.value);
-                            const headerTitle = selectedInstance.querySelector('.module-header div');
-                            if (headerTitle) {
-                                headerTitle.innerHTML = `<i class="fas fa-cube"></i> ${moduleName} - ${instanceNameEl.value}`;
-                            }
-                        }
-                        
-                        // Riattacca gli event listener dopo l'aggiornamento del DOM
-                        reattachModuleListeners();
-                    }
-                } else {
-                    console.error('Errore preview:', data.error);
-                    const moduleContent = selectedInstance.querySelector('.module-content');
-                    if (moduleContent) {
-                        moduleContent.innerHTML = '<div style="color: #dc3545; padding: 1rem;">Errore rendering: ' + (data.error || 'Errore sconosciuto') + '</div>';
-                    }
-                }
-            })
-            .catch(error => {
-                console.error('Error:', error);
-                const moduleContent = selectedInstance.querySelector('.module-content');
-                if (moduleContent) {
-                    moduleContent.innerHTML = '<div style="color: #dc3545; padding: 1rem;">Errore durante il caricamento: ' + error.message + '</div>';
-                }
-            });
-        }
-        
-        // Anteprima pagina
-        function previewPage() {
-            window.open(`../index.php?id_pagina=${currentPageId}`, '_blank');
-        }
-        
-        // Anteprima istanza
-        function previewInstance(instanceId) {
-            // Per ora apre la pagina completa
-            previewPage();
-        }
-        
-        // Chiudi modal anteprima
-        function closePreview() {
-            document.getElementById('preview-modal').style.display = 'none';
-        }
+        const PB_INITIAL_STATE = JSON.parse('<?php echo $initialJson; ?>');
     </script>
+    <script src="assets/js/page-builder.js"></script>
 </body>
 </html>

--- a/core/ModuleRenderer.php
+++ b/core/ModuleRenderer.php
@@ -23,20 +23,23 @@ class ModuleRenderer {
         if (!$page) {
             throw new Exception("Pagina non trovata: $slug");
         }
-        
+
         if ($useInstances) {
             $modules = $this->getPageModuleInstances($page['id']);
+            $moduleTree = $this->buildModuleInstanceTree($modules);
         } else {
             $modules = $this->getPageModules($page['id']);
+            $moduleTree = [];
         }
-        
+
         $cssVariables = $this->getCSSVariables($page);
-        
+
         return [
             'page' => $page,
             'modules' => $modules,
             'css_variables' => $cssVariables,
-            'use_instances' => $useInstances
+            'use_instances' => $useInstances,
+            'module_tree' => $moduleTree,
         ];
     }
     
@@ -58,13 +61,15 @@ class ModuleRenderer {
         }
         
         $modules = $this->getPageModuleInstances($pageId);
+        $moduleTree = $this->buildModuleInstanceTree($modules);
         $cssVariables = $this->getCSSVariables($page);
-        
+
         return [
             'page' => $page,
             'modules' => $modules,
             'css_variables' => $cssVariables,
-            'use_instances' => true
+            'use_instances' => true,
+            'module_tree' => $moduleTree,
         ];
     }
     
@@ -87,7 +92,11 @@ class ModuleRenderer {
 
         // Merge config default con config passato
         $finalConfig = $this->mergeConfigWithDefaults($moduleName, $config);
-        
+
+        if (!empty($finalConfig['__inline_html']) && is_string($finalConfig['__inline_html'])) {
+            return $finalConfig['__inline_html'];
+        }
+
         // Buffer per catturare l'output
         ob_start();
         // Passa les variabili necessarie al modulo
@@ -188,10 +197,67 @@ class ModuleRenderer {
         $sql = "SELECT mi.*
                 FROM module_instances mi
                 WHERE mi.page_id = ? AND mi.is_active = 1
-                ORDER BY mi.order_index";
+                ORDER BY COALESCE(mi.parent_instance_id, 0), mi.order_index";
         $stmt = $this->db->prepare($sql);
         $stmt->execute([$pageId]);
         return $stmt->fetchAll();
+    }
+
+    /**
+     * Costruisce albero annidato delle istanze di moduli
+     */
+    public function buildModuleInstanceTree(array $instances): array
+    {
+        if (empty($instances)) {
+            return [];
+        }
+
+        $byParent = [];
+        foreach ($instances as $instance) {
+            $parentId = $instance['parent_instance_id'] ?? null;
+            if ($parentId !== null) {
+                $parentId = (int)$parentId;
+            }
+
+            $byParent[$parentId ?? 0][] = $instance;
+        }
+
+        $build = function ($parentId) use (&$build, &$byParent) {
+            $result = [];
+            $bucketKey = $parentId ?? 0;
+            if (!isset($byParent[$bucketKey])) {
+                return $result;
+            }
+
+            foreach ($byParent[$bucketKey] as $instance) {
+                $node = $instance;
+                $node['children'] = $build((int)$instance['id']);
+                $result[] = $node;
+            }
+
+            return $result;
+        };
+
+        return $build(null);
+    }
+
+    /**
+     * Appiattisce un albero di istanze in lista
+     */
+    public function flattenModuleInstanceTree(array $tree): array
+    {
+        $flat = [];
+        foreach ($tree as $node) {
+            $nodeCopy = $node;
+            $children = $nodeCopy['children'] ?? [];
+            unset($nodeCopy['children']);
+            $flat[] = $nodeCopy;
+            if (!empty($children)) {
+                $flat = array_merge($flat, $this->flattenModuleInstanceTree($children));
+            }
+        }
+
+        return $flat;
     }
     
     /**

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -92,13 +92,16 @@ CREATE TABLE module_instances (
     instance_name VARCHAR(100) NOT NULL,
     config JSON,
     order_index INT DEFAULT 0,
+    parent_instance_id INT DEFAULT NULL,
     is_active BOOLEAN DEFAULT TRUE,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     FOREIGN KEY (page_id) REFERENCES pages(id) ON DELETE CASCADE,
+    FOREIGN KEY (parent_instance_id) REFERENCES module_instances(id) ON DELETE CASCADE,
     UNIQUE KEY unique_instance (page_id, instance_name),
     INDEX idx_page_order (page_id, order_index),
-    INDEX idx_module (module_name)
+    INDEX idx_module (module_name),
+    INDEX idx_parent (parent_instance_id)
 );
 
 -- Inserimento moduli base

--- a/index.php
+++ b/index.php
@@ -29,13 +29,49 @@ try {
         $pageData = $renderer->renderPage('home');
     }
     
-    $page = $pageData['page'];
-    $modules = $pageData['modules'];
-    $cssVariables = $pageData['css_variables'];
-    $useInstances = $pageData['use_instances'] ?? false;
-    
+$page = $pageData['page'];
+$modules = $pageData['modules'];
+$cssVariables = $pageData['css_variables'];
+$useInstances = $pageData['use_instances'] ?? false;
+$moduleTree = $pageData['module_tree'] ?? [];
+
 } catch (Exception $e) {
     die("Errore: " . $e->getMessage());
+}
+
+/**
+ * Render ricorsivo delle istanze modulo con supporto annidamento
+ */
+function renderModuleInstanceNode(ModuleRenderer $renderer, array $node): void
+{
+    $config = json_decode($node['config'] ?? '[]', true) ?? [];
+    $hasInlineHtml = isset($config['__inline_html']) && $config['__inline_html'] !== '';
+
+    echo '<div class="module-wrapper" data-module="' . htmlspecialchars($node['module_name']) . '"'
+        . ' data-instance="' . htmlspecialchars($node['instance_name']) . '"'
+        . ' data-instance-id="' . (int)$node['id'] . '"';
+
+    if (!empty($node['parent_instance_id'])) {
+        echo ' data-parent-id="' . (int)$node['parent_instance_id'] . '"';
+    }
+
+    echo '>';
+
+    if ($hasInlineHtml) {
+        echo $config['__inline_html'];
+    } else {
+        echo $renderer->renderModule($node['module_name'], $config);
+    }
+
+    if (!empty($node['children'])) {
+        echo '<div class="module-children">';
+        foreach ($node['children'] as $childNode) {
+            renderModuleInstanceNode($renderer, $childNode);
+        }
+        echo '</div>';
+    }
+
+    echo '</div>';
 }
 ?>
 <!DOCTYPE html>
@@ -136,16 +172,9 @@ try {
     <main id="main-content" class="site-main">
         <?php if ($useInstances): ?>
             <!-- Renderizza istanze di moduli (escluso menu) -->
-            <?php foreach ($modules as $instance): ?>
-                <?php if ($instance['module_name'] !== 'menu'): ?>
-                <div class="module-wrapper" data-module="<?= htmlspecialchars($instance['module_name']) ?>" 
-                     data-instance="<?= htmlspecialchars($instance['instance_name']) ?>">
-                    <?php
-                    $config = json_decode($instance['config'], true) ?? [];
-                    echo $renderer->renderModule($instance['module_name'], $config);
-                    ?>
-                </div>
-                <?php endif; ?>
+            <?php foreach ($moduleTree as $node): ?>
+                <?php if (($node['module_name'] ?? '') === 'menu') { continue; } ?>
+                <?php renderModuleInstanceNode($renderer, $node); ?>
             <?php endforeach; ?>
         <?php else: ?>
             <!-- Renderizza moduli tradizionali (escluso menu) -->


### PR DESCRIPTION
## Summary
- rebuild the admin page builder shell with a wider stage, contextual inspector, inline editing toggle and a dedicated JS controller for drag & drop, nested modules and page CRUD
- extend the page builder API to support parent-child relationships, inline HTML overrides and page lifecycle endpoints consumed by the new UI
- update the rendering stack and database schema to persist module hierarchy and replay inline HTML when rendering both the builder and public pages

## Testing
- php -l admin/api/page_builder.php
- php -l admin/page-builder.php
- php -l core/ModuleRenderer.php
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68e271687b94833081c52d52337916c5